### PR TITLE
Add unit tests for core components

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,18 @@
+import pytest
+from crystallize.core.context import FrozenContext, ContextMutationError
+
+
+def test_frozen_context_get_set():
+    ctx = FrozenContext({'a': 1})
+    assert ctx['a'] == 1
+
+    # adding new key is allowed
+    ctx['b'] = 2
+    assert ctx['b'] == 2
+
+    # attempting to mutate existing key should raise
+    with pytest.raises(ContextMutationError):
+        ctx['a'] = 3
+
+    as_dict = ctx.as_dict()
+    assert as_dict['a'] == 1 and as_dict['b'] == 2

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,0 +1,50 @@
+from crystallize.core.datasource import DataSource
+from crystallize.core.pipeline_step import PipelineStep
+from crystallize.core.pipeline import Pipeline
+from crystallize.core.hypothesis import Hypothesis
+from crystallize.core.stat_test import StatisticalTest
+from crystallize.core.treatment import Treatment
+from crystallize.core.experiment import Experiment
+from crystallize.core.context import FrozenContext
+
+
+class DummyDataSource(DataSource):
+    def fetch(self, ctx: FrozenContext):
+        # return replicate id plus any increment in ctx
+        return ctx['replicate'] + ctx.as_dict().get('increment', 0)
+
+
+class PassStep(PipelineStep):
+    def __call__(self, data, ctx):
+        return {'metric': data}
+
+    @property
+    def params(self):
+        return {}
+
+
+class AlwaysSignificant(StatisticalTest):
+    def run(self, baseline, treatment, *, alpha: float = 0.05):
+        return {'p_value': 0.01, 'significant': True}
+
+
+def test_experiment_run_basic():
+    pipeline = Pipeline([PassStep()])
+    datasource = DummyDataSource()
+    hypothesis = Hypothesis(
+        metric='metric', direction='increase', statistical_test=AlwaysSignificant()
+    )
+    treatment = Treatment('treat', lambda ctx: ctx.__setitem__('increment', 1))
+
+    experiment = Experiment(
+        datasource=datasource,
+        pipeline=pipeline,
+        treatments=[treatment],
+        hypothesis=hypothesis,
+        replicates=2,
+    )
+    result = experiment.run()
+    assert result.metrics['baseline']['metric'] == 0.5
+    assert result.metrics['treat']['metric'] == 1.5
+    assert result.metrics['hypothesis']['accepted'] is True
+    assert result.errors == {}

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -1,0 +1,22 @@
+from crystallize.core.hypothesis import Hypothesis
+from crystallize.core.stat_test import StatisticalTest
+
+
+class DummyStatTest(StatisticalTest):
+    def __init__(self, significant: bool):
+        self.significant = significant
+
+    def run(self, baseline, treatment, *, alpha: float = 0.05):
+        return {"p_value": 0.01, "significant": self.significant}
+
+
+def test_hypothesis_increase_accepted():
+    h = Hypothesis(metric="metric", direction="increase", statistical_test=DummyStatTest(True))
+    result = h.verify({"metric": 1}, {"metric": 2})
+    assert result["accepted"] is True
+
+
+def test_hypothesis_not_significant():
+    h = Hypothesis(metric="metric", direction="increase", statistical_test=DummyStatTest(False))
+    result = h.verify({"metric": 1}, {"metric": 2})
+    assert result["accepted"] is False

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,47 @@
+import pytest
+from typing import Any, Mapping
+
+from crystallize.core.pipeline import Pipeline, InvalidPipelineOutput
+from crystallize.core.pipeline_step import PipelineStep
+from crystallize.core.context import FrozenContext
+
+
+class AddStep(PipelineStep):
+    def __init__(self, value: int):
+        self.value = value
+
+    def __call__(self, data: Any, ctx: FrozenContext) -> Any:
+        return data + self.value
+
+    @property
+    def params(self) -> dict:
+        return {'value': self.value}
+
+
+class MetricsStep(PipelineStep):
+    def __call__(self, data: Any, ctx: FrozenContext) -> Mapping[str, Any]:
+        return {'result': data}
+
+    @property
+    def params(self) -> dict:
+        return {}
+
+
+def test_pipeline_runs_and_returns_metrics():
+    pipeline = Pipeline([AddStep(1), MetricsStep()])
+    ctx = FrozenContext({})
+    result = pipeline.run(0, ctx)
+    assert result == {'result': 1}
+
+
+def test_invalid_pipeline_output_raises():
+    pipeline = Pipeline([AddStep(1)])
+    ctx = FrozenContext({})
+    with pytest.raises(InvalidPipelineOutput):
+        pipeline.run(0, ctx)
+
+
+def test_pipeline_signature():
+    pipeline = Pipeline([AddStep(2), MetricsStep()])
+    sig = pipeline.signature()
+    assert "AddStep" in sig and "MetricsStep" in sig


### PR DESCRIPTION
## Summary
- add tests for `FrozenContext` immutability
- add pipeline component tests
- add hypothesis tests for accepted and rejected cases
- add experiment integration test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686df96397fc8329b7ae80446a5a8150