### PR TITLE
Add decorator-based pipeline API

### DIFF
--- a/crystallize/__init__.py
+++ b/crystallize/__init__.py
@@ -1,0 +1,91 @@
+"""Public API and helper decorators."""
+
+from __future__ import annotations
+
+import inspect
+from functools import update_wrapper
+from typing import Any, Callable, Optional
+
+from crystallize.core.context import FrozenContext
+from crystallize.core.hypothesis import Hypothesis
+from crystallize.core.pipeline_step import PipelineStep
+from crystallize.core.treatment import Treatment
+from crystallize.core.stat_test import StatisticalTest
+
+
+def pipeline_step(cacheable: bool = True) -> Callable[..., PipelineStep]:
+    """Decorate a function and convert it into a :class:`PipelineStep` factory."""
+
+    def decorator(fn: Callable[..., Any]) -> Callable[..., PipelineStep]:
+        sig = inspect.signature(fn)
+        param_names = [p.name for p in sig.parameters.values() if p.name not in {"data", "ctx"}]
+        defaults = {
+            name: p.default
+            for name, p in sig.parameters.items()
+            if name not in {"data", "ctx"} and p.default is not inspect.Signature.empty
+        }
+
+        is_cacheable = cacheable
+
+        def factory(**overrides: Any) -> PipelineStep:
+            params = {**defaults, **overrides}
+            missing = [n for n in param_names if n not in params]
+            if missing:
+                raise TypeError(f"Missing parameters: {', '.join(missing)}")
+
+            class FunctionStep(PipelineStep):
+                cacheable = is_cacheable
+
+                def __call__(self, data: Any, ctx: FrozenContext) -> Any:
+                    kwargs = {n: params[n] for n in param_names}
+                    return fn(data, ctx, **kwargs)
+
+                @property
+                def params(self) -> dict:
+                    return {n: params[n] for n in param_names}
+
+            FunctionStep.__name__ = f"{fn.__name__.title()}Step"
+            return FunctionStep()
+
+        return update_wrapper(factory, fn)
+
+    return decorator
+
+
+def treatment(name: str) -> Callable[..., Treatment]:
+    """Decorate a function to quickly create a :class:`Treatment`."""
+
+    def decorator(fn: Callable[[FrozenContext], Any]) -> Callable[..., Treatment]:
+        def factory() -> Treatment:
+            return Treatment(name, fn)
+
+        return update_wrapper(factory, fn)
+
+    return decorator
+
+
+def hypothesis(
+    *,
+    metric: str,
+    statistical_test: StatisticalTest,
+    alpha: float = 0.05,
+    direction: Optional[str] = None,
+) -> Callable[..., Hypothesis]:
+    """Decorator returning a :class:`Hypothesis` factory."""
+
+    def decorator(fn: Optional[Callable[..., Any]] = None) -> Callable[..., Hypothesis]:
+        def factory() -> Hypothesis:
+            return Hypothesis(
+                metric=metric,
+                statistical_test=statistical_test,
+                alpha=alpha,
+                direction=direction,
+            )
+
+        if fn is not None:
+            return update_wrapper(factory, fn)
+        return factory
+
+    return decorator
+
+__all__ = ["pipeline_step", "treatment", "hypothesis"]

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,49 @@
+from crystallize import hypothesis, pipeline_step, treatment
+from crystallize.core.context import FrozenContext
+from crystallize.core.pipeline import Pipeline
+from crystallize.core.stat_test import StatisticalTest
+
+
+@pipeline_step()
+def add(data, ctx, value=1):
+    return data + value
+
+
+@pipeline_step()
+def metrics(data, ctx):
+    return {"result": data}
+
+
+class DummyStatTest(StatisticalTest):
+    def run(self, baseline, treatment, *, alpha: float = 0.05):
+        return {"p_value": 0.01, "significant": True}
+
+
+@treatment("inc")
+def inc_treatment(ctx):
+    ctx["increment"] = 1
+
+
+@hypothesis(metric="result", statistical_test=DummyStatTest(), direction="increase")
+def result_hypo():
+    pass
+
+
+def test_pipeline_step_decorator():
+    pipeline = Pipeline([add(value=2), metrics()])
+    ctx = FrozenContext({})
+    result = pipeline.run(3, ctx)
+    assert result == {"result": 5}
+
+
+def test_treatment_decorator():
+    t = inc_treatment()
+    ctx = FrozenContext({})
+    t.apply(ctx)
+    assert ctx["increment"] == 1
+
+
+def test_hypothesis_decorator():
+    h = result_hypo()
+    res = h.verify({"result": [1, 2]}, {"result": [3, 4]})
+    assert res["accepted"] is True


### PR DESCRIPTION
### Summary

Introduce decorators that allow defining pipeline steps, treatments, and hypotheses using a concise function based syntax.

### Changes

- Added `pipeline_step`, `treatment`, and `hypothesis` decorators in `crystallize.__init__`
- New tests covering decorator usage

### Testing & Verification

- `pixi run lint`
- `pixi run test`


------
https://chatgpt.com/codex/tasks/task_e_686f8f42a9688329a8eb5a91227aa2b3