### PR TITLE
Add decorator-based pipeline API

### DIFF
--- a/crystallize/__init__.py
+++ b/crystallize/__init__.py
@@ -1,0 +1,21 @@
+"""Public convenience API."""
+
+from __future__ import annotations
+
+from .core import (
+    data_source,
+    hypothesis,
+    pipeline,
+    pipeline_step,
+    statistical_test,
+    treatment,
+)
+
+__all__ = [
+    "pipeline_step",
+    "treatment",
+    "hypothesis",
+    "data_source",
+    "statistical_test",
+    "pipeline",
+]

--- a/crystallize/core/__init__.py
+++ b/crystallize/core/__init__.py
@@ -1,0 +1,176 @@
+"""Convenience factories and decorators for core classes."""
+
+from __future__ import annotations
+
+import inspect
+from functools import update_wrapper
+from typing import Any, Callable, Optional
+
+from .context import FrozenContext
+from .datasource import DataSource
+from .hypothesis import Hypothesis
+from .pipeline import Pipeline
+from .pipeline_step import PipelineStep
+from .stat_test import StatisticalTest
+from .treatment import Treatment
+
+
+def pipeline_step(cacheable: bool = True) -> Callable[..., PipelineStep]:
+    """Decorate a function and convert it into a :class:`PipelineStep` factory."""
+
+    def decorator(fn: Callable[..., Any]) -> Callable[..., PipelineStep]:
+        sig = inspect.signature(fn)
+        param_names = [
+            p.name for p in sig.parameters.values() if p.name not in {"data", "ctx"}
+        ]
+        defaults = {
+            name: p.default
+            for name, p in sig.parameters.items()
+            if name not in {"data", "ctx"} and p.default is not inspect.Signature.empty
+        }
+
+        is_cacheable = cacheable
+
+        def factory(**overrides: Any) -> PipelineStep:
+            params = {**defaults, **overrides}
+            missing = [n for n in param_names if n not in params]
+            if missing:
+                raise TypeError(f"Missing parameters: {', '.join(missing)}")
+
+            class FunctionStep(PipelineStep):
+                cacheable = is_cacheable
+
+                def __call__(self, data: Any, ctx: FrozenContext) -> Any:
+                    kwargs = {n: params[n] for n in param_names}
+                    return fn(data, ctx, **kwargs)
+
+                @property
+                def params(self) -> dict:
+                    return {n: params[n] for n in param_names}
+
+            FunctionStep.__name__ = f"{fn.__name__.title()}Step"
+            return FunctionStep()
+
+        return update_wrapper(factory, fn)
+
+    return decorator
+
+
+def treatment(name: str) -> Callable[..., Treatment]:
+    """Decorate a function to quickly create a :class:`Treatment`."""
+
+    def decorator(fn: Callable[[FrozenContext], Any]) -> Callable[..., Treatment]:
+        def factory() -> Treatment:
+            return Treatment(name, fn)
+
+        return update_wrapper(factory, fn)
+
+    return decorator
+
+
+def hypothesis(
+    *,
+    metric: str,
+    statistical_test: StatisticalTest,
+    alpha: float = 0.05,
+    direction: Optional[str] = None,
+) -> Hypothesis:
+    """Create a :class:`Hypothesis` instance."""
+
+    return Hypothesis(
+        metric=metric,
+        statistical_test=statistical_test,
+        alpha=alpha,
+        direction=direction,
+    )
+
+
+def data_source(fn: Callable[..., Any]) -> Callable[..., DataSource]:
+    """Decorate a function to produce a :class:`DataSource` factory."""
+
+    sig = inspect.signature(fn)
+    param_names = [p.name for p in sig.parameters.values() if p.name != "ctx"]
+    defaults = {
+        name: p.default
+        for name, p in sig.parameters.items()
+        if name != "ctx" and p.default is not inspect.Signature.empty
+    }
+
+    def factory(**overrides: Any) -> DataSource:
+        params = {**defaults, **overrides}
+        missing = [n for n in param_names if n not in params]
+        if missing:
+            raise TypeError(f"Missing parameters: {', '.join(missing)}")
+
+        class FunctionSource(DataSource):
+            def fetch(self, ctx: FrozenContext) -> Any:
+                kwargs = {n: params[n] for n in param_names}
+                return fn(ctx, **kwargs)
+
+            @property
+            def params(self) -> dict:
+                return {n: params[n] for n in param_names}
+
+        FunctionSource.__name__ = f"{fn.__name__.title()}Source"
+        return FunctionSource()
+
+    return update_wrapper(factory, fn)
+
+
+def statistical_test(fn: Callable[..., Any]) -> Callable[..., StatisticalTest]:
+    """Decorate a function to produce a :class:`StatisticalTest` factory."""
+
+    sig = inspect.signature(fn)
+    param_names = [
+        p.name
+        for p in sig.parameters.values()
+        if p.name not in {"baseline", "treatment", "alpha"}
+    ]
+    defaults = {
+        name: p.default
+        for name, p in sig.parameters.items()
+        if name not in {"baseline", "treatment", "alpha"}
+        and p.default is not inspect.Signature.empty
+    }
+
+    def factory(**overrides: Any) -> StatisticalTest:
+        params = {**defaults, **overrides}
+        missing = [n for n in param_names if n not in params]
+        if missing:
+            raise TypeError(f"Missing parameters: {', '.join(missing)}")
+
+        class FunctionTest(StatisticalTest):
+            def run(
+                self,
+                baseline: Any,
+                treatment: Any,
+                *,
+                alpha: float = 0.05,
+            ) -> Any:
+                kwargs = {n: params[n] for n in param_names}
+                return fn(baseline, treatment, alpha=alpha, **kwargs)
+
+            @property
+            def params(self) -> dict:
+                return {n: params[n] for n in param_names}
+
+        FunctionTest.__name__ = f"{fn.__name__.title()}Test"
+        return FunctionTest()
+
+    return update_wrapper(factory, fn)
+
+
+def pipeline(*steps: PipelineStep) -> Pipeline:
+    """Instantiate a :class:`Pipeline` from the given steps."""
+
+    return Pipeline(list(steps))
+
+
+__all__ = [
+    "pipeline_step",
+    "treatment",
+    "hypothesis",
+    "data_source",
+    "statistical_test",
+    "pipeline",
+]

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,60 @@
+from crystallize import (
+    data_source,
+    hypothesis,
+    pipeline,
+    pipeline_step,
+    statistical_test,
+    treatment,
+)
+from crystallize.core.context import FrozenContext
+
+
+@pipeline_step()
+def add(data, ctx, value=1):
+    return data + value
+
+
+@pipeline_step()
+def metrics(data, ctx):
+    return {"result": data}
+
+
+@data_source
+def dummy_source(ctx, value=1):
+    return value
+
+
+@statistical_test
+def always_significant(baseline, treatment, *, alpha: float = 0.05):
+    return {"p_value": 0.01, "significant": True}
+
+
+@treatment("inc")
+def inc_treatment(ctx):
+    ctx["increment"] = 1
+
+
+h = hypothesis(
+    metric="result", statistical_test=always_significant(), direction="increase"
+)
+
+
+def test_pipeline_factory_and_decorators():
+    src = dummy_source(value=3)
+    pl = pipeline(add(value=2), metrics())
+    ctx = FrozenContext({})
+    data = src.fetch(ctx)
+    result = pl.run(data, ctx)
+    assert result == {"result": 5}
+
+
+def test_treatment_decorator():
+    t = inc_treatment()
+    ctx = FrozenContext({})
+    t.apply(ctx)
+    assert ctx["increment"] == 1
+
+
+def test_hypothesis_factory():
+    res = h.verify({"result": [1, 2]}, {"result": [3, 4]})
+    assert res["accepted"] is True


### PR DESCRIPTION
### Summary

Introduce decorators and helpers for easier scripting of core objects.

### Changes

- Moved pipeline step, treatment, and hypothesis helpers into `crystallize.core`
- Added new `data_source` and `statistical_test` decorators
- Added `pipeline` factory function for quick pipeline assembly
- Updated tests to cover new decorators and factory usage

### Testing & Verification

- `black crystallize/__init__.py crystallize/core/__init__.py tests/test_decorators.py`
- `pytest -q` *(fails: missing PyYAML)*

### Notes

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686f8f42a9688329a8eb5a91227aa2b3