### PR TITLE
Add multi-hypothesis support

### DIFF
--- a/crystallize/cli/main.py
+++ b/crystallize/cli/main.py
@@ -19,7 +19,7 @@ def main(argv: List[str] | None = None) -> None:
     if args.command == "run":
         experiment = load_experiment_from_file(args.config)
         result = experiment.run()
-        print(result.metrics["hypothesis"])
+        print(result.metrics["hypotheses"])
 
 
 if __name__ == "__main__":

--- a/crystallize/core/__init__.py
+++ b/crystallize/core/__init__.py
@@ -74,6 +74,7 @@ def hypothesis(
     statistical_test: StatisticalTest,
     alpha: float = 0.05,
     direction: Optional[str] = None,
+    name: Optional[str] = None,
 ) -> Hypothesis:
     """Create a :class:`Hypothesis` instance."""
 
@@ -82,6 +83,7 @@ def hypothesis(
         statistical_test=statistical_test,
         alpha=alpha,
         direction=direction,
+        name=name,
     )
 
 

--- a/crystallize/core/hypothesis.py
+++ b/crystallize/core/hypothesis.py
@@ -22,9 +22,11 @@ class Hypothesis:
         statistical_test: StatisticalTest,
         alpha: float = 0.05,
         direction: Optional[str] = None,
+        name: Optional[str] = None,
     ):
         assert direction in {"increase", "decrease", "equal", None}
         self.metric = metric
+        self.name = name or metric
         self.direction = direction
         self.statistical_test = statistical_test
         self.alpha = alpha
@@ -61,9 +63,11 @@ class Hypothesis:
             elif self.direction == "equal":
                 result["accepted"] = abs(treatment_mean - baseline_mean) < 1e-6
 
-            result.update({
-                "baseline_mean": baseline_mean,
-                "treatment_mean": treatment_mean,
-            })
+            result.update(
+                {
+                    "baseline_mean": baseline_mean,
+                    "treatment_mean": treatment_mean,
+                }
+            )
 
         return result

--- a/crystallize/tests/test_cli.py
+++ b/crystallize/tests/test_cli.py
@@ -1,15 +1,15 @@
 import subprocess
 import sys
-from pathlib import Path
 from ast import literal_eval
+from pathlib import Path
+
+import pytest
 
 from crystallize.core.context import FrozenContext
 from crystallize.core.datasource import DataSource
 from crystallize.core.pipeline_step import PipelineStep
 from crystallize.core.stat_test import StatisticalTest
 
-
-import pytest
 
 class DummyDataSource(DataSource):
     def fetch(self, ctx: FrozenContext):
@@ -29,6 +29,7 @@ class AlwaysSig(StatisticalTest):
     def run(self, baseline, treatment, *, alpha: float = 0.05):
         return {"p_value": 0.01, "significant": True}
 
+
 def apply_value(ctx: FrozenContext, amount: int) -> None:
     ctx["value"] = amount
 
@@ -36,7 +37,8 @@ def apply_value(ctx: FrozenContext, amount: int) -> None:
 @pytest.fixture
 def experiment_yaml(tmp_path: Path) -> Path:
     yaml_path = tmp_path / "exp.yaml"
-    yaml_path.write_text("""
+    yaml_path.write_text(
+        """
 replicates: 2
 datasource:
   target: crystallize.tests.test_cli.DummyDataSource
@@ -56,8 +58,10 @@ treatments:
       target: crystallize.tests.test_cli.apply_value
       params:
         amount: 1
-""")
+"""
+    )
     return yaml_path
+
 
 def test_cli_runs_from_yaml(experiment_yaml: Path):
     result = subprocess.run(
@@ -67,5 +71,5 @@ def test_cli_runs_from_yaml(experiment_yaml: Path):
         check=True,
     )
     output = literal_eval(result.stdout.strip())
-    assert output["increment"]["significant"] is True
-    assert output["increment"]["accepted"] is True
+    assert output["metric"]["increment"]["significant"] is True
+    assert output["metric"]["increment"]["accepted"] is True

--- a/examples/csv_pipeline_example/main.py
+++ b/examples/csv_pipeline_example/main.py
@@ -1,10 +1,6 @@
 from pathlib import Path
-from scipy.stats import ttest_ind
 
-from .datasource import CSVDataSource
-from .steps.metric import ExplainedVarianceStep
-from .steps.normalize import NormalizeStep
-from .steps.pca import PCAStep
+from scipy.stats import ttest_ind
 
 from crystallize.core.experiment import Experiment
 from crystallize.core.hypothesis import Hypothesis
@@ -12,14 +8,16 @@ from crystallize.core.pipeline import Pipeline
 from crystallize.core.stat_test import StatisticalTest
 from crystallize.core.treatment import Treatment
 
+from .datasource import CSVDataSource
+from .steps.metric import ExplainedVarianceStep
+from .steps.normalize import NormalizeStep
+from .steps.pca import PCAStep
+
 
 class WelchTTest(StatisticalTest):
     def run(self, baseline, treatment, *, alpha=0.05):
         t_stat, p_value = ttest_ind(baseline, treatment, equal_var=False)
-        return {
-            "p_value": p_value,
-            "significant": p_value < alpha
-        }
+        return {"p_value": p_value, "significant": p_value < alpha}
 
 
 def main() -> None:
@@ -40,12 +38,12 @@ def main() -> None:
         datasource=datasource,
         pipeline=pipeline,
         treatments=[treatment],
-        hypothesis=hypothesis,
+        hypotheses=[hypothesis],
         replicates=10,
     )
 
     result = experiment.run()
-    print(result.metrics['hypothesis'])
+    print(result.metrics["hypotheses"])
     print(result.provenance)
 
 

--- a/examples/minimal_experiment/main.py
+++ b/examples/minimal_experiment/main.py
@@ -1,43 +1,47 @@
-from crystallize.core.experiment import Experiment
-from crystallize.core.pipeline import Pipeline
-from crystallize.core.stat_test import StatisticalTest
 from crystallize.core.context import FrozenContext
 from crystallize.core.datasource import DataSource
-from crystallize.core.pipeline_step import PipelineStep
-from crystallize.core.treatment import Treatment
+from crystallize.core.experiment import Experiment
 from crystallize.core.hypothesis import Hypothesis
+from crystallize.core.pipeline import Pipeline
+from crystallize.core.pipeline_step import PipelineStep
+from crystallize.core.stat_test import StatisticalTest
+from crystallize.core.treatment import Treatment
+
 
 class AlwaysSignificant(StatisticalTest):
     def run(self, baseline, treatment, *, alpha: float = 0.05):
-        return {'p_value': 0.01, 'significant': True}
+        return {"p_value": 0.01, "significant": True}
+
 
 class DummyDataSource(DataSource):
     def fetch(self, ctx: FrozenContext):
-        return ctx.as_dict().get('increment', 0)
+        return ctx.as_dict().get("increment", 0)
+
 
 class PassStep(PipelineStep):
     def __call__(self, data, ctx):
-        return {'metric': data}
+        return {"metric": data}
 
     @property
     def params(self):
         return {}
 
-if __name__ == "__main__":
-  pipeline = Pipeline([PassStep()])
-  datasource = DummyDataSource()
-  hypothesis = Hypothesis(
-      metric='metric', direction='increase', statistical_test=AlwaysSignificant()
-  )
-  treatment = Treatment('treat', lambda ctx: ctx.__setitem__('increment', 1))
 
-  experiment = Experiment(
-      datasource=datasource,
-      pipeline=pipeline,
-      treatments=[treatment],
-      hypothesis=hypothesis,
-      replicates=2,
-  )
-  result = experiment.run()
-  print(result.metrics)
-  print(result.errors)
+if __name__ == "__main__":
+    pipeline = Pipeline([PassStep()])
+    datasource = DummyDataSource()
+    hypothesis = Hypothesis(
+        metric="metric", direction="increase", statistical_test=AlwaysSignificant()
+    )
+    treatment = Treatment("treat", lambda ctx: ctx.__setitem__("increment", 1))
+
+    experiment = Experiment(
+        datasource=datasource,
+        pipeline=pipeline,
+        treatments=[treatment],
+        hypotheses=[hypothesis],
+        replicates=2,
+    )
+    result = experiment.run()
+    print(result.metrics)
+    print(result.errors)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,22 +1,22 @@
+from crystallize.core.context import FrozenContext
 from crystallize.core.datasource import DataSource
-from crystallize.core.pipeline_step import PipelineStep
-from crystallize.core.pipeline import Pipeline
+from crystallize.core.experiment import Experiment
 from crystallize.core.hypothesis import Hypothesis
+from crystallize.core.pipeline import Pipeline
+from crystallize.core.pipeline_step import PipelineStep
 from crystallize.core.stat_test import StatisticalTest
 from crystallize.core.treatment import Treatment
-from crystallize.core.experiment import Experiment
-from crystallize.core.context import FrozenContext
 
 
 class DummyDataSource(DataSource):
     def fetch(self, ctx: FrozenContext):
         # return replicate id plus any increment in ctx
-        return ctx['replicate'] + ctx.as_dict().get('increment', 0)
+        return ctx["replicate"] + ctx.as_dict().get("increment", 0)
 
 
 class PassStep(PipelineStep):
     def __call__(self, data, ctx):
-        return {'metric': data}
+        return {"metric": data}
 
     @property
     def params(self):
@@ -25,48 +25,49 @@ class PassStep(PipelineStep):
 
 class AlwaysSignificant(StatisticalTest):
     def run(self, baseline, treatment, *, alpha: float = 0.05):
-        return {'p_value': 0.01, 'significant': True}
+        return {"p_value": 0.01, "significant": True}
 
 
 def test_experiment_run_basic():
     pipeline = Pipeline([PassStep()])
     datasource = DummyDataSource()
     hypothesis = Hypothesis(
-        metric='metric', direction='increase', statistical_test=AlwaysSignificant()
+        metric="metric", direction="increase", statistical_test=AlwaysSignificant()
     )
-    treatment = Treatment('treat', lambda ctx: ctx.__setitem__('increment', 1))
+    treatment = Treatment("treat", lambda ctx: ctx.__setitem__("increment", 1))
 
     experiment = Experiment(
         datasource=datasource,
         pipeline=pipeline,
         treatments=[treatment],
-        hypothesis=hypothesis,
+        hypotheses=[hypothesis],
         replicates=2,
     )
     result = experiment.run()
-    assert result.metrics['baseline']['metric'] == [0, 1]
-    assert result.metrics['treat']['metric'] == [1, 2]
-    assert result.metrics['hypothesis']['treat']['accepted'] is True
+    assert result.metrics["baseline"]["metric"] == [0, 1]
+    assert result.metrics["treat"]["metric"] == [1, 2]
+    assert result.metrics["hypotheses"][hypothesis.name]["treat"]["accepted"] is True
     assert result.errors == {}
+
 
 def test_experiment_run_multiple_treatments():
     pipeline = Pipeline([PassStep()])
     datasource = DummyDataSource()
     hypothesis = Hypothesis(
-        metric='metric', direction='increase', statistical_test=AlwaysSignificant()
+        metric="metric", direction="increase", statistical_test=AlwaysSignificant()
     )
-    treatment1 = Treatment('treat1', lambda ctx: ctx.__setitem__('increment', 1))
-    treatment2 = Treatment('treat2', lambda ctx: ctx.__setitem__('increment', 2))
+    treatment1 = Treatment("treat1", lambda ctx: ctx.__setitem__("increment", 1))
+    treatment2 = Treatment("treat2", lambda ctx: ctx.__setitem__("increment", 2))
     experiment = Experiment(
         datasource=datasource,
         pipeline=pipeline,
         treatments=[treatment1, treatment2],
-        hypothesis=hypothesis,
+        hypotheses=[hypothesis],
         replicates=2,
     )
     result = experiment.run()
-    assert result.metrics['baseline']['metric'] == [0, 1]
-    assert result.metrics['treat1']['metric'] == [1, 2]
-    assert result.metrics['treat2']['metric'] == [2, 3]
-    assert result.metrics['hypothesis']['treat1']['accepted'] is True
-    assert result.metrics['hypothesis']['treat2']['accepted'] is True
+    assert result.metrics["baseline"]["metric"] == [0, 1]
+    assert result.metrics["treat1"]["metric"] == [1, 2]
+    assert result.metrics["treat2"]["metric"] == [2, 3]
+    assert result.metrics["hypotheses"][hypothesis.name]["treat1"]["accepted"] is True
+    assert result.metrics["hypotheses"][hypothesis.name]["treat2"]["accepted"] is True

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -1,7 +1,9 @@
 import pytest
+
 from crystallize.core.exceptions import MissingMetricError
 from crystallize.core.hypothesis import Hypothesis
 from crystallize.core.stat_test import StatisticalTest
+
 
 class DummyStatTest(StatisticalTest):
     def __init__(self, significant: bool):
@@ -10,7 +12,9 @@ class DummyStatTest(StatisticalTest):
     def run(self, baseline, treatment, *, alpha: float = 0.05):
         return {"p_value": 0.01, "significant": self.significant}
 
+
 # Now baseline/treatment metrics are lists (multiple samples):
+
 
 def test_hypothesis_increase_accepted():
     h = Hypothesis(
@@ -21,6 +25,7 @@ def test_hypothesis_increase_accepted():
     result = h.verify({"metric": [1, 1.2, 0.9]}, {"metric": [2, 2.1, 2.2]})
     assert result["accepted"] is True
 
+
 def test_hypothesis_decrease_accepted():
     h = Hypothesis(
         metric="metric",
@@ -29,6 +34,7 @@ def test_hypothesis_decrease_accepted():
     )
     result = h.verify({"metric": [2, 2.1, 2.2]}, {"metric": [1, 1.2, 0.9]})
     assert result["accepted"] is True
+
 
 def test_hypothesis_increase_not_accepted_due_to_direction():
     h = Hypothesis(
@@ -39,6 +45,7 @@ def test_hypothesis_increase_not_accepted_due_to_direction():
     result = h.verify({"metric": [2, 2.1, 2.2]}, {"metric": [1, 1.1, 1.2]})
     assert result["accepted"] is False
 
+
 def test_hypothesis_not_significant():
     h = Hypothesis(
         metric="metric",
@@ -48,6 +55,7 @@ def test_hypothesis_not_significant():
     result = h.verify({"metric": [1, 1.1, 1.2]}, {"metric": [2, 2.1, 2.2]})
     assert result["accepted"] is False
 
+
 def test_missing_metric_error():
     h = Hypothesis(
         metric="missing",
@@ -56,6 +64,7 @@ def test_missing_metric_error():
     )
     with pytest.raises(MissingMetricError):
         h.verify({"metric": [1, 1.1, 1.2]}, {"metric": [2, 2.1, 2.2]})
+
 
 # New test for no-direction hypothesis
 def test_hypothesis_no_direction():
@@ -68,3 +77,13 @@ def test_hypothesis_no_direction():
     assert result["accepted"] is True
     assert "baseline_mean" not in result
     assert "treatment_mean" not in result
+
+
+def test_hypothesis_name_defaults_to_metric():
+    h = Hypothesis(metric="metric", statistical_test=DummyStatTest(True))
+    assert h.name == "metric"
+
+
+def test_hypothesis_custom_name():
+    h = Hypothesis(metric="metric", statistical_test=DummyStatTest(True), name="custom")
+    assert h.name == "custom"


### PR DESCRIPTION
### Summary

Adds ability for experiments to evaluate multiple hypotheses at once and adapts the CLI and examples accordingly.

### Changes

- Hypotheses now accept an optional `name` and default to the metric name
- Experiments accept a list of hypotheses and verify each independently
- CLI YAML loader and main updated for new hypothesis structure
- Examples and tests updated to use hypothesis lists

### Testing & Verification

- `pixi run lint`
- `pixi run test`


------
https://chatgpt.com/codex/tasks/task_e_686fa000a934832991318d5831adb5e6