### PR TITLE
Add experiment apply mode and optional configs

### DIFF
--- a/crystallize/core/__init__.py
+++ b/crystallize/core/__init__.py
@@ -10,7 +10,7 @@ from .context import FrozenContext
 from .datasource import DataSource
 from .hypothesis import Hypothesis
 from .pipeline import Pipeline
-from .pipeline_step import PipelineStep
+from .pipeline_step import PipelineStep, exit_step
 from .stat_test import StatisticalTest
 from .treatment import Treatment
 
@@ -170,6 +170,7 @@ def pipeline(*steps: PipelineStep) -> Pipeline:
 
 __all__ = [
     "pipeline_step",
+    "exit_step",
     "treatment",
     "hypothesis",
     "data_source",

--- a/crystallize/core/pipeline_step.py
+++ b/crystallize/core/pipeline_step.py
@@ -40,3 +40,10 @@ class PipelineStep(ABC):
 
         payload = {"class": self.__class__.__name__, "params": self.params}
         return compute_hash(payload)
+
+
+def exit_step(step: PipelineStep) -> PipelineStep:
+    """Mark a :class:`PipelineStep` instance as an exit point."""
+
+    setattr(step, "is_exit_step", True)
+    return step

--- a/examples/minimal_experiment/main.py
+++ b/examples/minimal_experiment/main.py
@@ -3,7 +3,7 @@ from crystallize.core.datasource import DataSource
 from crystallize.core.experiment import Experiment
 from crystallize.core.hypothesis import Hypothesis
 from crystallize.core.pipeline import Pipeline
-from crystallize.core.pipeline_step import PipelineStep
+from crystallize.core.pipeline_step import PipelineStep, exit_step
 from crystallize.core.stat_test import StatisticalTest
 from crystallize.core.treatment import Treatment
 
@@ -27,8 +27,17 @@ class PassStep(PipelineStep):
         return {}
 
 
+class IdentityStep(PipelineStep):
+    def __call__(self, data, ctx):
+        return data
+
+    @property
+    def params(self):
+        return {}
+
+
 if __name__ == "__main__":
-    pipeline = Pipeline([PassStep()])
+    pipeline = Pipeline([exit_step(IdentityStep()), PassStep()])
     datasource = DummyDataSource()
     hypothesis = Hypothesis(
         metric="metric", direction="increase", statistical_test=AlwaysSignificant()
@@ -45,3 +54,5 @@ if __name__ == "__main__":
     result = experiment.run()
     print(result.metrics)
     print(result.errors)
+    print("apply baseline:", experiment.apply(data=5))
+    print("apply treatment:", experiment.apply(treatment_name="treat", data=5))


### PR DESCRIPTION
### Summary

Enable more flexible experiment execution and production usage.

### Changes

- allow empty treatments and hypotheses in `Experiment`
- validate missing components and add `apply` method for single-run execution
- introduce `exit_step` marker for early pipeline exit
- update minimal example and tests for new behavior

### Testing & Verification

- `pixi run lint`
- `pixi run test`


------
https://chatgpt.com/codex/tasks/task_e_686fd1f0b6b88329a25026a2649e23fd