### PR TITLE
Add builder pattern and validation to Experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,15 @@ hypothesis = Hypothesis(metric="accuracy", direction="increase", statistical_tes
 
 treatment = Treatment(name="experiment_variant", apply_fn=lambda ctx: ctx.update({"learning_rate": 0.001}))
 
-experiment = Experiment(
-    pipeline=pipeline,
-    datasource=datasource,
-    treatments=[treatment],
-    hypothesis=hypothesis,
-    replicates=3,
+experiment = (
+    Experiment()
+    .with_pipeline(pipeline)
+    .with_datasource(datasource)
+    .with_treatments([treatment])
+    .with_hypotheses([hypothesis])
+    .with_replicates(3)
 )
+experiment.validate()
 
 result = experiment.run()
 print(result.metrics)

--- a/crystallize/cli/main.py
+++ b/crystallize/cli/main.py
@@ -18,6 +18,7 @@ def main(argv: List[str] | None = None) -> None:
 
     if args.command == "run":
         experiment = load_experiment_from_file(args.config)
+        experiment.validate()
         result = experiment.run()
         print(result.metrics["hypotheses"])
 

--- a/examples/csv_pipeline_example/main.py
+++ b/examples/csv_pipeline_example/main.py
@@ -34,14 +34,15 @@ def main() -> None:
         lambda ctx: ctx.__setitem__("csv_path", str(base_dir / "treatment.csv")),
     )
 
-    experiment = Experiment(
-        datasource=datasource,
-        pipeline=pipeline,
-        treatments=[treatment],
-        hypotheses=[hypothesis],
-        replicates=10,
+    experiment = (
+        Experiment()
+        .with_datasource(datasource)
+        .with_pipeline(pipeline)
+        .with_treatments([treatment])
+        .with_hypotheses([hypothesis])
+        .with_replicates(10)
     )
-
+    experiment.validate()
     result = experiment.run()
     print(result.metrics["hypotheses"])
     print(result.provenance)

--- a/examples/minimal_experiment/main.py
+++ b/examples/minimal_experiment/main.py
@@ -44,13 +44,15 @@ if __name__ == "__main__":
     )
     treatment = Treatment("treat", lambda ctx: ctx.__setitem__("increment", 1))
 
-    experiment = Experiment(
-        datasource=datasource,
-        pipeline=pipeline,
-        treatments=[treatment],
-        hypotheses=[hypothesis],
-        replicates=2,
+    experiment = (
+        Experiment()
+        .with_datasource(datasource)
+        .with_pipeline(pipeline)
+        .with_treatments([treatment])
+        .with_hypotheses([hypothesis])
+        .with_replicates(2)
     )
+    experiment.validate()
     result = experiment.run()
     print(result.metrics)
     print(result.errors)


### PR DESCRIPTION
### Summary

Introduce a fluent builder API and validation step for `Experiment`. Execution methods now require prior validation.

### Changes

- Added optional constructor parameters and new methods like `with_datasource`, `with_pipeline`, etc.
- Implemented `validate` with configuration checks; `run` and `apply` enforce validation.
- Updated CLI, tests, examples, and README to use the new API.
- Added tests for validation enforcement and builder chaining.

### Testing & Verification

- `pixi run lint`
- `pixi run test`


------
https://chatgpt.com/codex/tasks/task_e_686fe1184a3c832998dc37f6dcc92794