### PR TITLE
Update examples to use decorators

### DIFF
--- a/examples/csv_pipeline_example/datasource.py
+++ b/examples/csv_pipeline_example/datasource.py
@@ -3,30 +3,28 @@ import random
 from pathlib import Path
 from typing import List
 
-from crystallize.core.datasource import DataSource
+from crystallize import data_source
 from crystallize.core.context import FrozenContext
 
 
-class CSVDataSource(DataSource):
-    def __init__(self, default_path: str, ctx_key: str = "csv_path") -> None:
-        self.default_path = Path(default_path)
-        self.ctx_key = ctx_key
+@data_source
+def csv_data_source(
+    ctx: FrozenContext, default_path: str, ctx_key: str = "csv_path"
+) -> List[List[float]]:
+    path = Path(ctx.as_dict().get(ctx_key, default_path))
+    with path.open() as f:
+        reader = csv.DictReader(f)
+        all_rows = list(reader)
+        sampled_rows = random.sample(all_rows, min(4, len(all_rows)))
 
-    def fetch(self, ctx: FrozenContext) -> List[List[float]]:
-        path = Path(ctx.as_dict().get(self.ctx_key, self.default_path))
-        with path.open() as f:
-            reader = csv.DictReader(f)
-            all_rows = list(reader)
-            sampled_rows = random.sample(all_rows, min(4, len(all_rows)))
-
-            data = [
-                [
-                    float(row[field]) + random.uniform(-0.05, 0.05)  # add slight noise
-                    for field in reader.fieldnames
-                ]
-                for row in sampled_rows
+        data = [
+            [
+                float(row[field]) + random.uniform(-0.05, 0.05)  # add slight noise
+                for field in reader.fieldnames
             ]
-        return data
+            for row in sampled_rows
+        ]
+    return data
 
 
 def set_csv_path(ctx: FrozenContext, path: str, ctx_key: str = "csv_path") -> None:

--- a/examples/csv_pipeline_example/steps/metric.py
+++ b/examples/csv_pipeline_example/steps/metric.py
@@ -1,20 +1,14 @@
 from typing import Dict, List, Mapping
 
+from crystallize import pipeline_step
 from crystallize.core.context import FrozenContext
-from crystallize.core.pipeline_step import PipelineStep
 
 
-class ExplainedVarianceStep(PipelineStep):
+@pipeline_step()
+def explained_variance(data: Mapping[str, List[float]], ctx: FrozenContext) -> Dict[str, float]:
     """Compute explained variance ratio from eigenvalues."""
 
-    def __call__(
-        self, data: Mapping[str, List[float]], ctx: FrozenContext
-    ) -> Dict[str, float]:
-        eigvals = data.get("eigenvalues", [])
-        total = sum(eigvals)
-        ratio = eigvals[0] / total if total else 0.0
-        return {"explained_variance": ratio}
-
-    @property
-    def params(self) -> dict:
-        return {}
+    eigvals = data.get("eigenvalues", [])
+    total = sum(eigvals)
+    ratio = eigvals[0] / total if total else 0.0
+    return {"explained_variance": ratio}

--- a/examples/csv_pipeline_example/steps/normalize.py
+++ b/examples/csv_pipeline_example/steps/normalize.py
@@ -1,26 +1,20 @@
 import statistics
 from typing import List
 
+from crystallize import pipeline_step
 from crystallize.core.context import FrozenContext
-from crystallize.core.pipeline_step import PipelineStep
 
 
-class NormalizeStep(PipelineStep):
+@pipeline_step()
+def normalize(data: List[List[float]], ctx: FrozenContext) -> List[List[float]]:
     """Standardize columns to zero mean and unit variance."""
 
-    def __call__(
-        self, data: List[List[float]], ctx: FrozenContext
-    ) -> List[List[float]]:
-        if not data:
-            return data
-        columns = list(zip(*data))
-        means = [statistics.mean(col) for col in columns]
-        stdevs = [statistics.pstdev(col) or 1.0 for col in columns]
-        normalized = [
-            [(value - m) / s for value, m, s in zip(row, means, stdevs)] for row in data
-        ]
-        return normalized
-
-    @property
-    def params(self) -> dict:
-        return {}
+    if not data:
+        return data
+    columns = list(zip(*data))
+    means = [statistics.mean(col) for col in columns]
+    stdevs = [statistics.pstdev(col) or 1.0 for col in columns]
+    normalized = [
+        [(value - m) / s for value, m, s in zip(row, means, stdevs)] for row in data
+    ]
+    return normalized

--- a/examples/csv_pipeline_example/steps/pca.py
+++ b/examples/csv_pipeline_example/steps/pca.py
@@ -2,31 +2,25 @@ import math
 import statistics
 from typing import Dict, List
 
+from crystallize import pipeline_step
 from crystallize.core.context import FrozenContext
-from crystallize.core.pipeline_step import PipelineStep
 
 
-class PCAStep(PipelineStep):
+@pipeline_step()
+def pca(data: List[List[float]], ctx: FrozenContext) -> Dict[str, List[float]]:
     """PCA for 2D data using eigen decomposition."""
 
-    def __call__(
-        self, data: List[List[float]], ctx: FrozenContext
-    ) -> Dict[str, List[float]]:
-        if not data:
-            return {"eigenvalues": []}
-        if len(data[0]) != 2:
-            raise ValueError("PCAStep supports exactly 2 features for this example")
-        xs, ys = zip(*data)
-        mx, my = statistics.mean(xs), statistics.mean(ys)
-        var_x = statistics.pvariance(xs)
-        var_y = statistics.pvariance(ys)
-        cov_xy = sum((x - mx) * (y - my) for x, y in zip(xs, ys)) / len(data)
-        trace = var_x + var_y
-        det = var_x * var_y - cov_xy**2
-        lambda1 = trace / 2 + math.sqrt((trace / 2) ** 2 - det)
-        lambda2 = trace - lambda1
-        return {"eigenvalues": [lambda1, lambda2]}
-
-    @property
-    def params(self) -> dict:
-        return {}
+    if not data:
+        return {"eigenvalues": []}
+    if len(data[0]) != 2:
+        raise ValueError("PCAStep supports exactly 2 features for this example")
+    xs, ys = zip(*data)
+    mx, my = statistics.mean(xs), statistics.mean(ys)
+    var_x = statistics.pvariance(xs)
+    var_y = statistics.pvariance(ys)
+    cov_xy = sum((x - mx) * (y - my) for x, y in zip(xs, ys)) / len(data)
+    trace = var_x + var_y
+    det = var_x * var_y - cov_xy**2
+    lambda1 = trace / 2 + math.sqrt((trace / 2) ** 2 - det)
+    lambda2 = trace - lambda1
+    return {"eigenvalues": [lambda1, lambda2]}

--- a/examples/yaml_experiment/experiment.yaml
+++ b/examples/yaml_experiment/experiment.yaml
@@ -2,23 +2,23 @@
 replicates: 10
 
 datasource:
-  target: examples.csv_pipeline_example.datasource.CSVDataSource
+  target: examples.csv_pipeline_example.datasource.csv_data_source
   params:
     default_path: examples/csv_pipeline_example/baseline.csv
 
 pipeline:
-  - target: examples.csv_pipeline_example.steps.normalize.NormalizeStep
+  - target: examples.csv_pipeline_example.steps.normalize.normalize
     params: {}
-  - target: examples.csv_pipeline_example.steps.pca.PCAStep
+  - target: examples.csv_pipeline_example.steps.pca.pca
     params: {}
-  - target: examples.csv_pipeline_example.steps.metric.ExplainedVarianceStep
+  - target: examples.csv_pipeline_example.steps.metric.explained_variance
     params: {}
 
 hypothesis:
   metric: explained_variance
   direction: increase
   statistical_test:
-    target: examples.csv_pipeline_example.main.WelchTTest
+    target: examples.csv_pipeline_example.main.welch_t_test
     params: {}
 
 treatments:


### PR DESCRIPTION
### Summary
- refactor examples to use the new `crystallize` decorators
- adjust YAML config for decorator-based functions

### Changes
- simplify minimal example using decorator functions
- refactor CSV pipeline example with decorated steps and data source
- update YAML experiment references

### Testing & Verification
- `pixi run python examples/minimal_experiment/main.py`
- `pixi run python -m examples.csv_pipeline_example.main`
- `pixi run python -m crystallize.cli.main run examples/yaml_experiment/experiment.yaml`
- `pixi run lint`
- `pixi run test`


------
https://chatgpt.com/codex/tasks/task_e_686fe3517b088329a408e179fa6cb51a