### PR TITLE
Improve context and treatment usability

### DIFF
--- a/crystallize/core/context.py
+++ b/crystallize/core/context.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping
+from typing import Any, Mapping, Optional
 from types import MappingProxyType
 
 class ContextMutationError(Exception):
@@ -6,6 +6,8 @@ class ContextMutationError(Exception):
     pass
 
 class FrozenContext:
+    """Immutable execution context with safe mutation helpers."""
+
     def __init__(self, initial: Mapping[str, Any]):
         self._data = dict(initial)
 
@@ -16,6 +18,14 @@ class FrozenContext:
         if key in self._data:
             raise ContextMutationError(f"Cannot mutate existing key: '{key}'")
         self._data[key] = value
+
+    def add(self, key: str, value: Any) -> None:
+        """Alias for ``__setitem__`` providing a clearer API."""
+        self.__setitem__(key, value)
+
+    def get(self, key: str, default: Optional[Any] = None) -> Any:
+        """Return the value for ``key`` if present else ``default``."""
+        return self._data.get(key, default)
 
     def as_dict(self) -> Mapping[str, Any]:
         return MappingProxyType(self._data)

--- a/crystallize/tests/test_cli.py
+++ b/crystallize/tests/test_cli.py
@@ -31,7 +31,7 @@ class AlwaysSig(StatisticalTest):
 
 
 def apply_value(ctx: FrozenContext, amount: int) -> None:
-    ctx["value"] = amount
+    ctx.add("value", amount)
 
 
 @pytest.fixture

--- a/examples/csv_pipeline_example/datasource.py
+++ b/examples/csv_pipeline_example/datasource.py
@@ -29,4 +29,4 @@ def csv_data_source(
 
 def set_csv_path(ctx: FrozenContext, path: str, ctx_key: str = "csv_path") -> None:
     """Helper to update the CSV path in a context."""
-    ctx[ctx_key] = path
+    ctx.add(ctx_key, path)

--- a/examples/csv_pipeline_example/main.py
+++ b/examples/csv_pipeline_example/main.py
@@ -23,9 +23,10 @@ def welch_t_test(baseline, treatment, *, alpha: float = 0.05):
     return {"p_value": p_value, "significant": p_value < alpha}
 
 
-@treatment("better_data")
-def better_data(ctx: FrozenContext) -> None:
-    ctx["csv_path"] = str(Path(__file__).parent / "treatment.csv")
+better_data = treatment(
+    "better_data",
+    {"csv_path": str(Path(__file__).parent / "treatment.csv")},
+)
 
 
 def main() -> None:
@@ -37,7 +38,7 @@ def main() -> None:
         statistical_test=welch_t_test(),
         direction="increase",
     )
-    treat = better_data()
+    treat = better_data
 
     experiment = (
         Experiment()

--- a/examples/minimal_experiment/main.py
+++ b/examples/minimal_experiment/main.py
@@ -33,7 +33,7 @@ def identity_step(data, ctx):
 
 @treatment("treat")
 def treat(ctx: FrozenContext) -> None:
-    ctx["increment"] = 1
+    ctx.add("increment", 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,11 +4,11 @@ from crystallize.core.context import FrozenContext, ContextMutationError
 
 def test_frozen_context_get_set():
     ctx = FrozenContext({'a': 1})
-    assert ctx['a'] == 1
+    assert ctx.get('a') == 1
 
     # adding new key is allowed
-    ctx['b'] = 2
-    assert ctx['b'] == 2
+    ctx.add('b', 2)
+    assert ctx.get('b') == 2
 
     # attempting to mutate existing key should raise
     with pytest.raises(ContextMutationError):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -31,7 +31,7 @@ def always_significant(baseline, treatment, *, alpha: float = 0.05):
 
 @treatment("inc")
 def inc_treatment(ctx):
-    ctx["increment"] = 1
+    ctx.add("increment", 1)
 
 
 h = hypothesis(
@@ -52,7 +52,14 @@ def test_treatment_decorator():
     t = inc_treatment()
     ctx = FrozenContext({})
     t.apply(ctx)
-    assert ctx["increment"] == 1
+    assert ctx.get("increment") == 1
+
+
+def test_treatment_factory_with_mapping():
+    t = treatment("inc_map", {"increment": 2})
+    ctx = FrozenContext({})
+    t.apply(ctx)
+    assert ctx.get("increment") == 2
 
 
 def test_hypothesis_factory():

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -36,7 +36,7 @@ def test_experiment_run_basic():
     hypothesis = Hypothesis(
         metric="metric", direction="increase", statistical_test=AlwaysSignificant()
     )
-    treatment = Treatment("treat", lambda ctx: ctx.__setitem__("increment", 1))
+    treatment = Treatment("treat", {"increment": 1})
 
     experiment = Experiment(
         datasource=datasource,
@@ -59,8 +59,8 @@ def test_experiment_run_multiple_treatments():
     hypothesis = Hypothesis(
         metric="metric", direction="increase", statistical_test=AlwaysSignificant()
     )
-    treatment1 = Treatment("treat1", lambda ctx: ctx.__setitem__("increment", 1))
-    treatment2 = Treatment("treat2", lambda ctx: ctx.__setitem__("increment", 2))
+    treatment1 = Treatment("treat1", {"increment": 1})
+    treatment2 = Treatment("treat2", {"increment": 2})
     experiment = Experiment(
         datasource=datasource,
         pipeline=pipeline,
@@ -94,7 +94,7 @@ def test_experiment_run_baseline_only():
 def test_experiment_run_treatments_no_hypotheses():
     pipeline = Pipeline([PassStep()])
     datasource = DummyDataSource()
-    treatment = Treatment("treat", lambda ctx: ctx.__setitem__("increment", 1))
+    treatment = Treatment("treat", {"increment": 1})
 
     experiment = Experiment(
         datasource=datasource,
@@ -157,9 +157,7 @@ def test_experiment_builder_chaining():
         Experiment()
         .with_datasource(DummyDataSource())
         .with_pipeline(Pipeline([PassStep()]))
-        .with_treatments(
-            [Treatment("t", lambda ctx: ctx.__setitem__("increment", 1))]
-        )
+        .with_treatments([Treatment("t", {"increment": 1})])
         .with_hypotheses(
             [
                 Hypothesis(


### PR DESCRIPTION
### Summary

Adds helper APIs to make context manipulation and treatment creation easier.

### Changes

- `FrozenContext` now includes `add` and `get` helpers
- `Treatment` accepts a mapping of overrides or a callable
- `core.treatment` factory handles mapping or callable inputs
- Updated examples and tests to use new APIs

### Testing & Verification

- `pixi run lint`
- `pixi run test`


------
https://chatgpt.com/codex/tasks/task_e_686fe53ff6548329b6d39b9f6199129a