### PR TITLE
Add metrics context and ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,13 @@ from crystallize.core import (
 # Example setup (simple)
 pipeline = Pipeline([...])
 datasource = DataSource(...)
-hypothesis = Hypothesis(metric="accuracy", verifier=WelchTTest())
+t_test = WelchTTest()
+
+@hypothesis(verifier=t_test, metrics="accuracy")
+def rank_by_p(result):
+    return result["p_value"]
+
+hypothesis = rank_by_p()
 
 treatment = Treatment(name="experiment_variant", apply_fn=lambda ctx: ctx.update({"learning_rate": 0.001}))
 

--- a/crystallize/cli/yaml_loader.py
+++ b/crystallize/cli/yaml_loader.py
@@ -63,10 +63,12 @@ def load_experiment(config: Mapping[str, Any]) -> Experiment:
 
     for spec in hyp_specs:
         verifier_fn = _instantiate(spec["verifier"])
+        ranker_fn = _load_attr(spec["ranker"])
         hypotheses.append(
             Hypothesis(
-                metric=spec["metric"],
                 verifier=verifier_fn,
+                metrics=spec.get("metrics", spec.get("metric")),
+                ranker=ranker_fn,
                 name=spec.get("name"),
             )
         )

--- a/crystallize/core/context.py
+++ b/crystallize/core/context.py
@@ -1,15 +1,33 @@
-from typing import Any, Mapping, Optional
+from collections import defaultdict
 from types import MappingProxyType
+from typing import Any, DefaultDict, List, Mapping, Optional
 
 class ContextMutationError(Exception):
     """Raised when attempting to mutate an existing key in FrozenContext."""
     pass
+
+class FrozenMetrics:
+    """Immutable mapping of metric lists with safe append."""
+
+    def __init__(self) -> None:
+        self._metrics: DefaultDict[str, List[Any]] = defaultdict(list)
+
+    def __getitem__(self, key: str) -> List[Any]:
+        return self._metrics[key]
+
+    def add(self, key: str, value: Any) -> None:
+        self._metrics[key].append(value)
+
+    def as_dict(self) -> Mapping[str, List[Any]]:
+        return MappingProxyType(self._metrics)
+
 
 class FrozenContext:
     """Immutable execution context with safe mutation helpers."""
 
     def __init__(self, initial: Mapping[str, Any]):
         self._data = dict(initial)
+        self.metrics = FrozenMetrics()
 
     def __getitem__(self, key: str) -> Any:
         return self._data[key]

--- a/crystallize/core/hypothesis.py
+++ b/crystallize/core/hypothesis.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Mapping, Sequence, Optional, Dict, List
+from typing import Any, Callable, Dict, Mapping, Sequence, Optional
 
 from crystallize.core.exceptions import MissingMetricError
 
@@ -8,13 +8,20 @@ class Hypothesis:
 
     def __init__(
         self,
-        metric: str | Sequence[str],
         verifier: Callable[[Mapping[str, Sequence[Any]], Mapping[str, Sequence[Any]]], Mapping[str, Any]],
+        metrics: str | Sequence[str] | Sequence[Sequence[str]] | None = None,
+        ranker: Callable[[Mapping[str, Any]], float] | None = None,
         name: Optional[str] = None,
     ) -> None:
-        self.metric_list: List[str] = [metric] if isinstance(metric, str) else list(metric)
-        self.name = name or (metric if isinstance(metric, str) else "_".join(self.metric_list))
+        self.metrics_spec = metrics
         self.verifier = verifier
+        self.ranker = ranker or (lambda res: float(res.get("p_value", 0.0)))
+        if name:
+            self.name = name
+        elif hasattr(ranker, "__name__"):
+            self.name = ranker.__name__  # type: ignore[arg-type]
+        else:
+            self.name = "hypothesis"
 
     # ---- public API -----------------------------------------------------
 
@@ -22,15 +29,37 @@ class Hypothesis:
         self,
         baseline_metrics: Mapping[str, Sequence[Any]],
         treatment_metrics: Mapping[str, Sequence[Any]],
-    ) -> Mapping[str, Any]:
-        baseline_samples: Dict[str, Sequence[Any]] = {}
-        treatment_samples: Dict[str, Sequence[Any]] = {}
+    ) -> Any:
+        def subset(keys: Sequence[str]) -> tuple[Dict[str, Sequence[Any]], Dict[str, Sequence[Any]]]:
+            b: Dict[str, Sequence[Any]] = {}
+            t: Dict[str, Sequence[Any]] = {}
+            for k in keys:
+                try:
+                    b[k] = baseline_metrics[k]
+                    t[k] = treatment_metrics[k]
+                except KeyError:
+                    raise MissingMetricError(k)
+            return b, t
 
-        for m in self.metric_list:
-            try:
-                baseline_samples[m] = baseline_metrics[m]
-                treatment_samples[m] = treatment_metrics[m]
-            except KeyError:
-                raise MissingMetricError(m)
+        spec = self.metrics_spec
+        if spec is None:
+            groups = [list(baseline_metrics.keys())]
+        elif isinstance(spec, str):
+            groups = [[spec]]
+        elif spec and isinstance(spec[0], Sequence) and not isinstance(spec[0], (str, bytes)):  # type: ignore[index]
+            groups = [list(g) for g in spec]  # type: ignore[arg-type]
+        else:
+            groups = [list(spec)]  # type: ignore[arg-type]
 
-        return self.verifier(baseline_samples, treatment_samples)
+        outputs = []
+        for group in groups:
+            b, t = subset(group)
+            outputs.append(self.verifier(b, t))
+
+        return outputs[0] if len(outputs) == 1 else outputs
+
+    def rank_treatments(self, verifier_results: Mapping[str, Any]) -> Mapping[str, Any]:
+        scores = {name: self.ranker(res) for name, res in verifier_results.items()}
+        ranked = sorted(scores.items(), key=lambda x: x[1])
+        best = ranked[0][0] if ranked else None
+        return {"best": best, "ranked": ranked}

--- a/crystallize/core/pipeline.py
+++ b/crystallize/core/pipeline.py
@@ -42,7 +42,7 @@ class Pipeline:
             InvalidPipelineOutput: if the last step does not return Mapping.
         """
         provenance = []
-        for step in self.steps:
+        for i, step in enumerate(self.steps):
             step_hash = step.step_hash
             input_hash = compute_hash(data)
             if step.cacheable:
@@ -74,6 +74,10 @@ class Pipeline:
                     "cache_hit": cache_hit,
                 }
             )
+
+            if cache_hit and i == len(self.steps) - 1 and isinstance(data, Mapping):
+                for key, value in data.items():
+                    ctx.metrics.add(key, value)
 
         self._provenance = tuple(MappingProxyType(p) for p in provenance)
         if not isinstance(data, Mapping):

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -31,12 +31,17 @@ def process(data, ctx):
 
 @pipeline_step()
 def metrics(data, ctx):
+    ctx.metrics.add("result", data)
     return {"result": data}
 
 @verifier
 def t_test(baseline, treatment, *, alpha=0.05):
     # Implement or use scipy
     return {"p_value": 0.01, "significant": True}
+
+@hypothesis(verifier=t_test(), metrics="result")
+def ranker(res):
+    return res["p_value"]
 
 treatment_example = treatment("add_one", {"value": 1})
 
@@ -45,7 +50,7 @@ exp = (
     .datasource(dummy_data)
     .pipeline([process, metrics])
     .treatments([treatment_example])
-    .hypotheses([hypothesis(metric="result", verifier=t_test())])
+    .hypotheses([ranker()])
     .replicates(5)
     .build()
 )

--- a/examples/csv_pipeline_example/main.py
+++ b/examples/csv_pipeline_example/main.py
@@ -24,12 +24,17 @@ better_data = treatment(
 )
 
 
+def rank_by_p(result: dict) -> float:
+    return result["p_value"]
+
+
 def main() -> None:
     base_dir = Path(__file__).parent
-    hyp = hypothesis(
-        metric="explained_variance",
-        verifier=welch_t_test(),
-    )
+    @hypothesis(verifier=welch_t_test(), metrics="explained_variance")
+    def hyp(result):
+        return result["p_value"]
+
+    hyp = hyp()
     treat = better_data
 
     experiment = (

--- a/examples/csv_pipeline_example/steps/metric.py
+++ b/examples/csv_pipeline_example/steps/metric.py
@@ -11,4 +11,5 @@ def explained_variance(data: Mapping[str, List[float]], ctx: FrozenContext) -> D
     eigvals = data.get("eigenvalues", [])
     total = sum(eigvals)
     ratio = eigvals[0] / total if total else 0.0
+    ctx.metrics.add("explained_variance", ratio)
     return {"explained_variance": ratio}

--- a/examples/minimal_experiment/main.py
+++ b/examples/minimal_experiment/main.py
@@ -26,6 +26,7 @@ def dummy_source(ctx: FrozenContext):
 
 @pipeline_step()
 def pass_step(data, ctx):
+    ctx.metrics.add("metric", data)
     return {"metric": data}
 
 
@@ -41,9 +42,11 @@ def treat(ctx: FrozenContext) -> None:
 
 
 if __name__ == "__main__":
-    hyp = hypothesis(
-        metric="metric", verifier=always_significant()
-    )
+    @hypothesis(verifier=always_significant(), metrics="metric")
+    def hyp(result):
+        return result["p_value"]
+
+    hyp = hyp()
     treat_step = treat()
 
     experiment = (

--- a/examples/yaml_experiment/experiment.yaml
+++ b/examples/yaml_experiment/experiment.yaml
@@ -1,28 +1,26 @@
-# pixi run python -m crystallize.cli.main run examples/yaml_experiment/experiment.yaml
-replicates: 10
-
-datasource:
-  target: examples.csv_pipeline_example.datasource.csv_data_source
-  params:
-    default_path: examples/csv_pipeline_example/baseline.csv
-
-pipeline:
-  - target: examples.csv_pipeline_example.steps.normalize.normalize
-    params: {}
-  - target: examples.csv_pipeline_example.steps.pca.pca
-    params: {}
-  - target: examples.csv_pipeline_example.steps.metric.explained_variance
-    params: {}
-
-hypothesis:
-  metric: explained_variance
-  verifier:
-    target: examples.csv_pipeline_example.main.welch_t_test
-    params: {}
-
-treatments:
-  - name: better_data
-    apply:
-      target: examples.csv_pipeline_example.datasource.set_csv_path
-      params:
-        path: examples/csv_pipeline_example/treatment.csv
+{
+  "replicates": 10,
+  "datasource": {
+    "target": "examples.csv_pipeline_example.datasource.csv_data_source",
+    "params": {"default_path": "examples/csv_pipeline_example/baseline.csv"}
+  },
+  "pipeline": [
+    {"target": "examples.csv_pipeline_example.steps.normalize.normalize", "params": {}},
+    {"target": "examples.csv_pipeline_example.steps.pca.pca", "params": {}},
+    {"target": "examples.csv_pipeline_example.steps.metric.explained_variance", "params": {}}
+  ],
+  "hypothesis": {
+    "metrics": "explained_variance",
+    "verifier": {"target": "examples.csv_pipeline_example.main.welch_t_test", "params": {}},
+    "ranker": "examples.csv_pipeline_example.main.rank_by_p"
+  },
+  "treatments": [
+    {
+      "name": "better_data",
+      "apply": {
+        "target": "examples.csv_pipeline_example.datasource.set_csv_path",
+        "params": {"path": "examples/csv_pipeline_example/treatment.csv"}
+      }
+    }
+  ]
+}

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -17,8 +17,9 @@ def add(data, ctx, value=1):
     return data + value
 
 
-@pipeline_step()
+@pipeline_step(cacheable=False)
 def metrics(data, ctx):
+    ctx.metrics.add("result", data)
     return {"result": data}
 
 
@@ -37,10 +38,9 @@ def inc_treatment(ctx):
     ctx.add("increment", 1)
 
 
-h = hypothesis(
-    metric="result",
-    verifier=always_significant(),
-)
+@hypothesis(verifier=always_significant(), metrics="result")
+def h(result):
+    return result["p_value"]
 
 
 def test_pipeline_factory_and_decorators():

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -12,24 +12,24 @@ def make_verifier(accepted: bool):
 
 
 def test_verify_returns_result():
-    hyp = Hypothesis(metric="metric", verifier=make_verifier(True))
+    hyp = Hypothesis(verifier=make_verifier(True), metrics="metric", ranker=lambda r: 0.0)
     result = hyp.verify({"metric": [1, 2]}, {"metric": [3, 4]})
     assert result["accepted"] is True
 
 
 def test_missing_metric_error():
-    hyp = Hypothesis(metric="metric", verifier=make_verifier(True))
+    hyp = Hypothesis(verifier=make_verifier(True), metrics="metric", ranker=lambda r: 0.0)
     with pytest.raises(MissingMetricError):
         hyp.verify({"other": [1]}, {"metric": [2]})
 
 
 def test_name_defaults_to_metric():
-    hyp = Hypothesis(metric="metric", verifier=make_verifier(True))
-    assert hyp.name == "metric"
+    hyp = Hypothesis(verifier=make_verifier(True), metrics="metric", ranker=lambda r: 0.0)
+    assert hyp.name == "<lambda>"
 
 
 def test_custom_name():
-    hyp = Hypothesis(metric="metric", verifier=make_verifier(True), name="custom")
+    hyp = Hypothesis(verifier=make_verifier(True), metrics="metric", ranker=lambda r: 0.0, name="custom")
     assert hyp.name == "custom"
 
 
@@ -40,7 +40,7 @@ def test_multi_metric():
             "sum_treatment": sum(treatment["a"]) + sum(treatment["b"]),
         }
 
-    hyp = Hypothesis(metric=["a", "b"], verifier=verifier)
+    hyp = Hypothesis(verifier=verifier, metrics=["a", "b"], ranker=lambda r: 0.0)
     res = hyp.verify({"a": [1], "b": [2]}, {"a": [3], "b": [4]})
     assert res["sum_baseline"] == 3 and res["sum_treatment"] == 7
 


### PR DESCRIPTION
### Summary
Implements ranking of treatments and introduces an immutable metrics container.

### Changes
- add `FrozenMetrics` to execution context
- update `Hypothesis` to support grouped metrics and ranking
- allow `@hypothesis` decorator to wrap rankers
- aggregate metrics via context and rank treatments in `Experiment`
- handle cached pipeline outputs when recording metrics
- update examples, CLI loader and tests for new API

### Testing & Verification
- `pixi run lint`
- `pixi run test`


------
https://chatgpt.com/codex/tasks/task_e_6871b7a35b408329a59778592bffb775