### PR TITLE
Add missing type hints

### DIFF
--- a/crystallize/cli/yaml_loader.py
+++ b/crystallize/cli/yaml_loader.py
@@ -8,12 +8,12 @@ from typing import Any, Callable, List, Mapping
 try:  # Prefer PyYAML if available
     import yaml  # type: ignore
 
-    def _yaml_load(content: str):
+    def _yaml_load(content: str) -> Any:
         return yaml.safe_load(content)
 
 except Exception:  # pragma: no cover - fallback when PyYAML missing
 
-    def _yaml_load(content: str):
+    def _yaml_load(content: str) -> Any:
         return json.loads(content)
 
 

--- a/crystallize/core/context.py
+++ b/crystallize/core/context.py
@@ -2,9 +2,12 @@ from collections import defaultdict
 from types import MappingProxyType
 from typing import Any, DefaultDict, List, Mapping, Optional
 
+
 class ContextMutationError(Exception):
     """Raised when attempting to mutate an existing key in FrozenContext."""
+
     pass
+
 
 class FrozenMetrics:
     """Immutable mapping of metric lists with safe append."""
@@ -25,14 +28,14 @@ class FrozenMetrics:
 class FrozenContext:
     """Immutable execution context with safe mutation helpers."""
 
-    def __init__(self, initial: Mapping[str, Any]):
+    def __init__(self, initial: Mapping[str, Any]) -> None:
         self._data = dict(initial)
         self.metrics = FrozenMetrics()
 
     def __getitem__(self, key: str) -> Any:
         return self._data[key]
 
-    def __setitem__(self, key: str, value: Any):
+    def __setitem__(self, key: str, value: Any) -> None:
         if key in self._data:
             raise ContextMutationError(f"Cannot mutate existing key: '{key}'")
         self._data[key] = value

--- a/crystallize/core/exceptions.py
+++ b/crystallize/core/exceptions.py
@@ -5,13 +5,13 @@ class CrystallizeError(Exception):
 class MissingMetricError(CrystallizeError):
     """Raised when a required metric is missing from the pipeline's output."""
 
-    def __init__(self, metric: str):
+    def __init__(self, metric: str) -> None:
         super().__init__(f"Required metric '{metric}' missing from pipeline output.")
 
 
 class PipelineExecutionError(CrystallizeError):
     """Raised when a pipeline step fails unexpectedly."""
 
-    def __init__(self, step_name: str, original_exception: Exception):
+    def __init__(self, step_name: str, original_exception: Exception) -> None:
         super().__init__(f"Step '{step_name}' failed: {str(original_exception)}")
         self.original_exception = original_exception

--- a/crystallize/core/pipeline.py
+++ b/crystallize/core/pipeline.py
@@ -20,7 +20,7 @@ class Pipeline:
     intermediate representation.
     """
 
-    def __init__(self, steps: List[PipelineStep]):
+    def __init__(self, steps: List[PipelineStep]) -> None:
         if not steps:
             raise ValueError("Pipeline must contain at least one step.")
         self.steps = steps

--- a/crystallize/core/result.py
+++ b/crystallize/core/result.py
@@ -1,13 +1,14 @@
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
+
 
 class Result:
     def __init__(
-        self, 
-        metrics: Dict[str, Any], 
+        self,
+        metrics: Dict[str, Any],
         artifacts: Optional[Dict[str, Any]] = None,
         errors: Optional[Dict[str, Exception]] = None,
-        provenance: Optional[Dict[str, Any]] = None
-    ):
+        provenance: Optional[Dict[str, Any]] = None,
+    ) -> None:
         self.metrics = metrics
         self.artifacts = artifacts or {}
         self.errors = errors or {}


### PR DESCRIPTION
### Summary
- add return annotations to various initializer methods
- ensure FrozenContext and Result constructors are typed
- type YAML helper functions

### Changes
- `FrozenContext.__init__` and `__setitem__` now specify `-> None`
- error and pipeline initializer return types annotated
- `_yaml_load` helper typed

### Testing & Verification
- `ruff check crystallize tests`
- `pytest -q` *(fails: numpy missing)*

### Notes
- Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6871cae1dab8832995b89827d0f44378