### PR TITLE
Add optional parallel experiment execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ experiment = (
     .treatments([treatment])
     .hypotheses([hypothesis])
     .replicates(3)
+    .parallel(True)
     .build()
 )
 result = experiment.run()

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ experiment = (
     .replicates(3)
     .parallel(True)
     .max_workers(4)
-    .executor_type("thread")
+    .executor_type("thread")  # or "process" for CPU-bound steps
     .build()
 )
 result = experiment.run()

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ experiment = (
     .hypotheses([hypothesis])
     .replicates(3)
     .parallel(True)
+    .max_workers(4)
+    .executor_type("thread")
     .build()
 )
 result = experiment.run()

--- a/crystallize/cli/yaml_loader.py
+++ b/crystallize/cli/yaml_loader.py
@@ -80,6 +80,10 @@ def load_experiment(config: Mapping[str, Any]) -> Experiment:
 
     replicates = int(config.get("replicates", 1))
     parallel = bool(config.get("parallel", False))
+    max_workers = config.get("max_workers")
+    if max_workers is not None:
+        max_workers = int(max_workers)
+    executor_type = config.get("executor_type", "thread")
     return Experiment(
         datasource=datasource,
         pipeline=pipeline,
@@ -87,6 +91,8 @@ def load_experiment(config: Mapping[str, Any]) -> Experiment:
         hypotheses=hypotheses,
         replicates=replicates,
         parallel=parallel,
+        max_workers=max_workers,
+        executor_type=executor_type,
     )
 
 

--- a/crystallize/cli/yaml_loader.py
+++ b/crystallize/cli/yaml_loader.py
@@ -79,12 +79,14 @@ def load_experiment(config: Mapping[str, Any]) -> Experiment:
         treatments.append(Treatment(t_spec["name"], apply_fn))
 
     replicates = int(config.get("replicates", 1))
+    parallel = bool(config.get("parallel", False))
     return Experiment(
         datasource=datasource,
         pipeline=pipeline,
         treatments=treatments,
         hypotheses=hypotheses,
         replicates=replicates,
+        parallel=parallel,
     )
 
 

--- a/crystallize/core/builder.py
+++ b/crystallize/core/builder.py
@@ -67,6 +67,10 @@ class ExperimentBuilder:
         return self
 
     def executor_type(self, executor_type: str) -> "ExperimentBuilder":
+        if executor_type not in Experiment.VALID_EXECUTOR_TYPES:
+            raise ValueError(
+                f"executor_type must be one of {Experiment.VALID_EXECUTOR_TYPES}, got '{executor_type}'"
+            )
         self._executor_type = executor_type
         return self
 

--- a/crystallize/core/builder.py
+++ b/crystallize/core/builder.py
@@ -26,6 +26,7 @@ class ExperimentBuilder:
         self._treatments: List[Treatment] = []
         self._hypotheses: List[Hypothesis] = []
         self._replicates: int = 1
+        self._parallel: bool = False
 
     # ------------------------------------------------------------------ #
     def datasource(
@@ -55,6 +56,10 @@ class ExperimentBuilder:
         self._replicates = max(1, replicates)
         return self
 
+    def parallel(self, parallel: bool) -> "ExperimentBuilder":
+        self._parallel = parallel
+        return self
+
     # ------------------------------------------------------------------ #
     def _instantiate(self, item: Any) -> Any:
         if isinstance(item, PipelineStep):
@@ -76,6 +81,7 @@ class ExperimentBuilder:
             treatments=self._treatments,
             hypotheses=self._hypotheses,
             replicates=self._replicates,
+            parallel=self._parallel,
         )
         exp.validate()
         return exp

--- a/crystallize/core/builder.py
+++ b/crystallize/core/builder.py
@@ -27,6 +27,8 @@ class ExperimentBuilder:
         self._hypotheses: List[Hypothesis] = []
         self._replicates: int = 1
         self._parallel: bool = False
+        self._max_workers: Optional[int] = None
+        self._executor_type: str = "thread"
 
     # ------------------------------------------------------------------ #
     def datasource(
@@ -60,6 +62,14 @@ class ExperimentBuilder:
         self._parallel = parallel
         return self
 
+    def max_workers(self, max_workers: Optional[int]) -> "ExperimentBuilder":
+        self._max_workers = max_workers
+        return self
+
+    def executor_type(self, executor_type: str) -> "ExperimentBuilder":
+        self._executor_type = executor_type
+        return self
+
     # ------------------------------------------------------------------ #
     def _instantiate(self, item: Any) -> Any:
         if isinstance(item, PipelineStep):
@@ -82,6 +92,8 @@ class ExperimentBuilder:
             hypotheses=self._hypotheses,
             replicates=self._replicates,
             parallel=self._parallel,
+            max_workers=self._max_workers,
+            executor_type=self._executor_type,
         )
         exp.validate()
         return exp

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -52,6 +52,7 @@ exp = (
     .treatments([treatment_example])
     .hypotheses([ranker()])
     .replicates(5)
+    .parallel(True)  # run replicates concurrently
     .build()
 )
 result = exp.run()
@@ -69,5 +70,6 @@ print(output)
 - Treatments as dicts or callables.
 - Multi-hypothesis verification.
 - Fluent builders and prod apply mode.
+- Optional parallel execution for heavy experiments.
 
 For full API, see code/docs. Issues? File at [repo link].

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -53,6 +53,7 @@ exp = (
     .hypotheses([ranker()])
     .replicates(5)
     .parallel(True)  # run replicates concurrently
+    .max_workers(4)
     .build()
 )
 result = exp.run()
@@ -71,5 +72,9 @@ print(output)
 - Multi-hypothesis verification.
 - Fluent builders and prod apply mode.
 - Optional parallel execution for heavy experiments.
+- Configurable worker count and executor type.
+
+For heavy parallel workloads, ensure the cache directory supports file locks or
+switch to a thread-safe backend.
 
 For full API, see code/docs. Issues? File at [repo link].

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -54,6 +54,7 @@ exp = (
     .replicates(5)
     .parallel(True)  # run replicates concurrently
     .max_workers(4)
+    .executor_type("thread")  # use "process" for CPU heavy steps
     .build()
 )
 result = exp.run()
@@ -72,7 +73,7 @@ print(output)
 - Multi-hypothesis verification.
 - Fluent builders and prod apply mode.
 - Optional parallel execution for heavy experiments.
-- Configurable worker count and executor type.
+- Configurable worker count and executor type ("thread" or "process").
 
 For heavy parallel workloads, ensure the cache directory supports file locks or
 switch to a thread-safe backend.


### PR DESCRIPTION
### Summary

Adds optional threaded parallelism for running experiment replicates. This improves performance on large experiments.

### Changes

- Introduced `parallel` flag in `Experiment` with `with_parallel` helper
- Updated `Experiment.run` to dispatch replicates via `ThreadPoolExecutor`
- Extended `ExperimentBuilder` and YAML loader to configure parallel mode
- Documented feature and updated examples
- Added unit test verifying parallel execution matches serial results

### Testing & Verification

- `pixi run lint`
- `pixi run test`


------
https://chatgpt.com/codex/tasks/task_e_6871d0c5ec2c8329965ef94b34b0dd7d