### PR TITLE
Introduce dataclass metrics

### DIFF
--- a/crystallize/cli/main.py
+++ b/crystallize/cli/main.py
@@ -20,7 +20,11 @@ def main(argv: List[str] | None = None) -> None:
         experiment = load_experiment_from_file(args.config)
         experiment.validate()
         result = experiment.run()
-        print(result.metrics["hypotheses"])
+        hyp_map = {
+            h.name: {"results": h.results, "ranking": h.ranking}
+            for h in result.metrics.hypotheses
+        }
+        print(hyp_map)
 
 
 if __name__ == "__main__":

--- a/crystallize/core/result.py
+++ b/crystallize/core/result.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 from typing import Any, Dict, Optional
+
+from .result_structs import ExperimentMetrics, HypothesisResult
 
 
 class Result:
     def __init__(
         self,
-        metrics: Dict[str, Any],
+        metrics: ExperimentMetrics,
         artifacts: Optional[Dict[str, Any]] = None,
         errors: Optional[Dict[str, Exception]] = None,
         provenance: Optional[Dict[str, Any]] = None,
@@ -14,8 +18,12 @@ class Result:
         self.errors = errors or {}
         self.provenance = provenance or {}
 
-    def get_metrics(self, key: str) -> Any:
-        return self.metrics.get(key)
-
     def get_artifact(self, name: str) -> Any:
         return self.artifacts.get(name)
+
+    # Convenience
+    def get_hypothesis(self, name: str) -> Optional[HypothesisResult]:
+        return next(
+            (h for h in self.metrics.hypotheses if h.name == name),
+            None,
+        )

--- a/crystallize/core/result_structs.py
+++ b/crystallize/core/result_structs.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+try:
+    import pandas as pd
+except Exception:  # pragma: no cover - pandas is optional
+    pd = None  # type: ignore
+
+
+@dataclass
+class TreatmentMetrics:
+    metrics: Dict[str, List[Any]]
+
+
+@dataclass
+class HypothesisResult:
+    name: str
+    results: Dict[str, Dict[str, Any]]
+    ranking: Dict[str, Any]
+
+    def get_for_treatment(self, treatment: str) -> Optional[Dict[str, Any]]:
+        return self.results.get(treatment)
+
+
+@dataclass
+class ExperimentMetrics:
+    baseline: TreatmentMetrics
+    treatments: Dict[str, TreatmentMetrics]
+    hypotheses: List[HypothesisResult]
+
+    def to_df(self):
+        if pd is None:  # pragma: no cover - optional dependency
+            raise ImportError("pandas is required for to_df()")
+        rows = []
+        for hyp in self.hypotheses:
+            for treat, res in hyp.results.items():
+                rows.append({"condition": treat, "hypothesis": hyp.name, **res})
+        return pd.DataFrame(rows)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -112,7 +112,7 @@ def test_experiment_builder_integration():
         .replicates(1)
         .build_and_run()
     )
-    assert result.metrics["baseline"]["result"] == [5]
+    assert result.metrics.baseline.metrics["result"] == [5]
 
 
 def test_builder_negative_replicates_clamped():

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -135,7 +135,8 @@ def test_full_experiment_with_scipy_verifier():
     exp = Experiment(datasource=ds, pipeline=pipeline, treatments=[treatment], hypotheses=[hyp], replicates=3)
     exp.validate()
     result = exp.run()
-    assert "p_value" in result.metrics["hypotheses"][hyp.name]["results"]["shift"]
+    hyp_res = result.get_hypothesis(hyp.name)
+    assert hyp_res is not None and "p_value" in hyp_res.results["shift"]
 
 
 @verifier

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,7 +4,7 @@ import pytest
 
 from crystallize.core.context import FrozenContext
 from crystallize.core.exceptions import PipelineExecutionError
-from crystallize.core.pipeline import InvalidPipelineOutput, Pipeline
+from crystallize.core.pipeline import Pipeline
 from crystallize.core.pipeline_step import PipelineStep, exit_step
 
 

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,12 +1,17 @@
 from crystallize.core.result import Result
+from crystallize.core.result_structs import ExperimentMetrics, TreatmentMetrics
 
 
 def test_result_accessors_and_errors():
-    metrics = {"a": 1}
+    metrics = ExperimentMetrics(
+        baseline=TreatmentMetrics({"a": [1]}),
+        treatments={},
+        hypotheses=[],
+    )
     artifacts = {"model": object()}
     errors = {"run": RuntimeError("fail")}
     r = Result(metrics=metrics, artifacts=artifacts, errors=errors)
-    assert r.get_metrics("a") == 1
+    assert r.metrics.baseline.metrics["a"] == [1]
     assert r.get_artifact("model") is artifacts["model"]
     assert r.errors == errors
 

--- a/tests/test_yaml_loader.py
+++ b/tests/test_yaml_loader.py
@@ -63,8 +63,8 @@ def test_load_experiment_success(json_config: Path):
     exp = load_experiment_from_file(json_config)
     exp.validate()
     result = exp.run()
-    assert result.metrics["baseline"]["result"] == [2, 3]
-    assert result.metrics["inc"]["result"] == [2, 3]
+    assert result.metrics.baseline.metrics["result"] == [2, 3]
+    assert result.metrics.treatments["inc"].metrics["result"] == [2, 3]
 
 
 def test_load_experiment_invalid(tmp_path: Path):


### PR DESCRIPTION
### Summary

Introduce dataclasses for experiment results and update API usage.

### Changes

- add `ExperimentMetrics`, `TreatmentMetrics`, and `HypothesisResult` dataclasses
- refactor `Experiment.run` and `Result` to use new structures
- update CLI to output hypothesis results from dataclasses
- adjust tests to new metrics API

### Testing & Verification

- `pixi run lint`
- `pixi run test`


------
https://chatgpt.com/codex/tasks/task_e_6872007dfce88329b6d88620b5ac7b72