### PR TITLE
Add auto seeding to experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ experiment = (
     .hypotheses([hypothesis])
     .replicates(3)
     .seed(42)
+    # optional custom seed function
+    # .seed_fn(my_seed_function)
     .parallel(True)
     .max_workers(4)
     .executor_type("thread")  # or "process" for CPU-bound steps

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ experiment = (
     .treatments([treatment])
     .hypotheses([hypothesis])
     .replicates(3)
+    .seed(42)
     .parallel(True)
     .max_workers(4)
     .executor_type("thread")  # or "process" for CPU-bound steps

--- a/crystallize/core/builder.py
+++ b/crystallize/core/builder.py
@@ -27,6 +27,8 @@ class ExperimentBuilder:
         self._hypotheses: List[Hypothesis] = []
         self._replicates: int = 1
         self._parallel: bool = False
+        self._seed: Optional[int] = None
+        self._auto_seed: bool = True
         self._max_workers: Optional[int] = None
         self._executor_type: str = "thread"
 
@@ -60,6 +62,14 @@ class ExperimentBuilder:
 
     def parallel(self, parallel: bool) -> "ExperimentBuilder":
         self._parallel = parallel
+        return self
+
+    def seed(self, seed: Optional[int]) -> "ExperimentBuilder":
+        self._seed = seed
+        return self
+
+    def auto_seed(self, auto: bool) -> "ExperimentBuilder":
+        self._auto_seed = auto
         return self
 
     def max_workers(self, max_workers: Optional[int]) -> "ExperimentBuilder":
@@ -96,6 +106,8 @@ class ExperimentBuilder:
             hypotheses=self._hypotheses,
             replicates=self._replicates,
             parallel=self._parallel,
+            seed=self._seed,
+            auto_seed=self._auto_seed,
             max_workers=self._max_workers,
             executor_type=self._executor_type,
         )

--- a/crystallize/core/builder.py
+++ b/crystallize/core/builder.py
@@ -29,6 +29,7 @@ class ExperimentBuilder:
         self._parallel: bool = False
         self._seed: Optional[int] = None
         self._auto_seed: bool = True
+        self._seed_fn: Optional[Callable[[int], None]] = None
         self._max_workers: Optional[int] = None
         self._executor_type: str = "thread"
 
@@ -72,6 +73,10 @@ class ExperimentBuilder:
         self._auto_seed = auto
         return self
 
+    def seed_fn(self, fn: Callable[[int], None]) -> "ExperimentBuilder":
+        self._seed_fn = fn
+        return self
+
     def max_workers(self, max_workers: Optional[int]) -> "ExperimentBuilder":
         self._max_workers = max_workers
         return self
@@ -108,6 +113,7 @@ class ExperimentBuilder:
             parallel=self._parallel,
             seed=self._seed,
             auto_seed=self._auto_seed,
+            seed_fn=self._seed_fn,
             max_workers=self._max_workers,
             executor_type=self._executor_type,
         )

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -52,6 +52,7 @@ exp = (
     .treatments([treatment_example])
     .hypotheses([ranker()])
     .replicates(5)
+    .seed(42)
     .parallel(True)  # run replicates concurrently
     .max_workers(4)
     .executor_type("thread")  # use "process" for CPU heavy steps

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -53,6 +53,8 @@ exp = (
     .hypotheses([ranker()])
     .replicates(5)
     .seed(42)
+    # optionally customize seeding
+    # .seed_fn(my_seed_function)
     .parallel(True)  # run replicates concurrently
     .max_workers(4)
     .executor_type("thread")  # use "process" for CPU heavy steps

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,4 +1,6 @@
 import time
+import random
+import numpy as np
 import pytest
 
 from crystallize.core.context import FrozenContext
@@ -667,3 +669,51 @@ def test_high_replicates_parallel_no_issues():
     exp.validate()
     result = exp.run()
     assert len(result.metrics.baseline.metrics["metric"]) == 50
+
+
+class RandomDataSource(DataSource):
+    def fetch(self, ctx: FrozenContext):
+        return np.random.random()
+
+
+class RandomStep(PipelineStep):
+    cacheable = False
+
+    def __call__(self, data, ctx):
+        val = data + random.random()
+        ctx.metrics.add("rand", val)
+        return {"rand": val}
+
+    @property
+    def params(self):
+        return {}
+
+
+def test_auto_seed_reproducible_serial_vs_parallel():
+    pipeline = Pipeline([RandomStep()])
+    ds = RandomDataSource()
+    serial = Experiment(
+        datasource=ds,
+        pipeline=pipeline,
+        replicates=3,
+        seed=123,
+        auto_seed=True,
+    )
+    serial.validate()
+    res_serial = serial.run()
+
+    parallel = Experiment(
+        datasource=ds,
+        pipeline=pipeline,
+        replicates=3,
+        seed=123,
+        auto_seed=True,
+        parallel=True,
+    )
+    parallel.validate()
+    res_parallel = parallel.run()
+
+    assert res_serial.metrics == res_parallel.metrics
+    assert res_serial.provenance["seeds"] == res_parallel.provenance["seeds"]
+    expected = [hash((123, rep, "baseline")) for rep in range(3)]
+    assert res_serial.provenance["seeds"]["baseline"] == expected


### PR DESCRIPTION
### Summary
Adds deterministic seeding for each pipeline run so stochastic experiments are reproducible.

### Changes
- introduce `seed` and `auto_seed` options on `Experiment` and builder
- compute per-run seed inside `_run_condition` and capture in result provenance
- update documentation and examples to show `.seed()` usage
- add unit test verifying deterministic behaviour in serial and parallel modes

### Testing & Verification
- `pixi run lint`
- `pixi run test`


------
https://chatgpt.com/codex/tasks/task_e_687221d52f5083298af8a51223d22319