### PR TITLE
Add provenance tree summary

### DIFF
--- a/crystallize/core/result.py
+++ b/crystallize/core/result.py
@@ -27,3 +27,127 @@ class Result:
             (h for h in self.metrics.hypotheses if h.name == name),
             None,
         )
+
+    # ------------------------------------------------------------------ #
+    def print_tree(self, fmt: str = "treatment > replicate > step") -> None:
+        """Print a tree summary of execution provenance."""
+        tokens = [t.strip().lower() for t in fmt.split(">")]
+        valid = {"treatment", "replicate", "step", "action"}
+        if any(tok not in valid for tok in tokens):
+            raise ValueError(f"Invalid format spec: {fmt}")
+        if "action" in tokens and tokens[-1] != "action":
+            raise ValueError("'action' must be the final element if present")
+
+        changes = self.provenance.get("ctx_changes", {})
+        rows = []
+        for treatment, reps in changes.items():
+            for rep, steps in reps.items():
+                for record in steps:
+                    acts = record.get("ctx_changes", {})
+                    if not any(acts.get(a) for a in ("reads", "wrote", "metrics")):
+                        continue
+                    rows.append(
+                        {
+                            "treatment": treatment,
+                            "replicate": rep,
+                            "step": record.get("step", ""),
+                            "actions": acts,
+                        }
+                    )
+
+        try:
+            from rich.console import Console
+            from rich.tree import Tree
+
+            use_rich = True
+        except Exception:  # pragma: no cover - optional dependency
+            use_rich = False
+
+        class Node:
+            def __init__(self, label: str, style: Optional[str] = None) -> None:
+                self.label = label
+                self.style = style
+                self.children: list["Node"] = []
+
+            def add(self, label: str, style: Optional[str] = None) -> "Node":
+                child = Node(label, style)
+                self.children.append(child)
+                return child
+
+        root = Node("Experiment Summary", "bold yellow")
+
+        def add_actions(parent: Node, acts: Dict[str, Any]) -> None:
+            mapping = {
+                "reads": ("Reads", "green"),
+                "wrote": ("Writes", "blue"),
+                "metrics": ("Metrics", "red"),
+            }
+            for key, (label, style) in mapping.items():
+                details = acts.get(key, {})
+                if not details:
+                    continue
+                act_node = parent.add(label, style)
+                if key == "reads":
+                    for k, v in details.items():
+                        act_node.add(f"{k}={v}")
+                else:
+                    for k, change in details.items():
+                        before = change.get("before")
+                        after = change.get("after")
+                        act_node.add(f"{k}: {before} -> {after}")
+
+        def build(node: Node, subset: list[dict], level: int) -> None:
+            if level == len(tokens):
+                for row in subset:
+                    step_node = node
+                    if "step" not in tokens:
+                        step_node = node.add(f"Step {row['step']}", "bold yellow")
+                    add_actions(step_node, row["actions"])
+                return
+
+            token = tokens[level]
+            if token == "action":
+                for row in subset:
+                    step_node = node
+                    if "step" not in tokens[: level]:
+                        step_node = node.add(f"Step {row['step']}", "bold yellow")
+                    add_actions(step_node, row["actions"])
+                return
+
+            groups: Dict[Any, list[dict]] = {}
+            for row in subset:
+                groups.setdefault(row[token], []).append(row)
+
+            for key in sorted(groups):
+                if token == "treatment":
+                    label = f"Treatment '{key}'"
+                elif token == "replicate":
+                    label = f"Replicate {key}"
+                else:  # step
+                    label = f"Step {key}"
+                child = node.add(label, "bold yellow")
+                build(child, groups[key], level + 1)
+
+        build(root, rows, 0)
+
+        if use_rich:
+            console = Console()
+
+            def to_rich(rnode: Node) -> Tree:
+                label = (
+                    f"[{rnode.style}]" + rnode.label + "[/]" if rnode.style else rnode.label
+                )
+                r_tree = Tree(label)
+                for c in rnode.children:
+                    r_tree.add(to_rich(c))
+                return r_tree
+
+            console.print(to_rich(root))
+        else:  # pragma: no cover - fallback
+            def print_plain(pnode: Node, depth: int = 0) -> None:
+                indent = "  " * depth
+                print(f"{indent}{pnode.label}")
+                for c in pnode.children:
+                    print_plain(c, depth + 1)
+
+            print_plain(root)

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -15,3 +15,32 @@ def test_result_accessors_and_errors():
     assert r.get_artifact("model") is artifacts["model"]
     assert r.errors == errors
 
+
+def test_print_tree_plain_output(capsys):
+    metrics = ExperimentMetrics(
+        baseline=TreatmentMetrics({}),
+        treatments={},
+        hypotheses=[],
+    )
+    provenance = {
+        "ctx_changes": {
+            "baseline": {
+                0: [
+                    {
+                        "step": "AddStep",
+                        "ctx_changes": {
+                            "reads": {"x": 1},
+                            "wrote": {},
+                            "metrics": {},
+                        },
+                    }
+                ]
+            }
+        }
+    }
+    r = Result(metrics=metrics, provenance=provenance)
+    r.print_tree()
+    output = capsys.readouterr().out
+    assert "AddStep" in output
+    assert "x=1" in output
+


### PR DESCRIPTION
### Summary

Introduce a readable execution summary for experiment results.

### Changes

- store per-run context changes in experiment provenance
- provide `Result.print_tree()` for colored or plain summaries
- fall back to plain output when `rich` is unavailable
- add regression tests for the new method

### Testing & Verification

- `pixi run lint`
- `pixi run test`


------
https://chatgpt.com/codex/tasks/task_e_68743ace1be48329a53b0bfe474973de