### PR TITLE
Investigate provenance issue in minimal example

### DIFF
--- a/crystallize/core/experiment.py
+++ b/crystallize/core/experiment.py
@@ -175,7 +175,7 @@ class Experiment:
             self.replicates,
             run_ctx.get("condition"),
         )
-        self.pipeline.run(
+        _, prov = self.pipeline.run(
             data,
             run_ctx,
             verbose=self.verbose,
@@ -183,8 +183,9 @@ class Experiment:
             rep=run_ctx.get("replicate"),
             condition=run_ctx.get("condition"),
             logger=logger,
+            return_provenance=True,
         )
-        return run_ctx.metrics.as_dict(), local_seed, self.pipeline.get_provenance()
+        return run_ctx.metrics.as_dict(), local_seed, prov
 
     # ------------------------------------------------------------------ #
 

--- a/crystallize/core/pipeline.py
+++ b/crystallize/core/pipeline.py
@@ -28,7 +28,8 @@ class Pipeline:
         rep: Optional[int] = None,
         condition: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
-    ) -> Any:
+        return_provenance: bool = False,
+    ) -> Any | Tuple[Any, List[Mapping[str, Any]]]:
         """
         Execute the pipeline in order.
 
@@ -37,7 +38,9 @@ class Pipeline:
             ctx:  Immutable execution context.
 
         Returns:
-            Any: Output from the last step in the pipeline.
+            If ``return_provenance`` is ``False`` (default), returns the output
+            from the last step. Otherwise returns a tuple ``(output,
+            provenance)`` where ``provenance`` is a list of step records.
         """
         logger = logger or logging.getLogger("crystallize")
 
@@ -125,9 +128,10 @@ class Pipeline:
             len(self.steps),
         )
 
+        if return_provenance:
+            return data, list(self._provenance)
         return data
 
-    # ------------------------------------------------------------------ #
 
     def signature(self) -> str:
         """Hash‐friendly signature for caching/provenance."""

--- a/examples/minimal_experiment/main.py
+++ b/examples/minimal_experiment/main.py
@@ -26,6 +26,8 @@ def add_delta(data, ctx: FrozenContext):
 def add_random(data, ctx: FrozenContext):
     # Add some random noise to the data
     # This removes scipy's "catastrophic cancellation" error
+    replicate = ctx.get('replicate', 0)
+    treatment = ctx.get('condition', 'add_ten_treatment')
     return [x + random.random() for x in data]
 
 @pipeline_step()


### PR DESCRIPTION
### Summary
- explore minimal example results and capture per-run provenance
- `Pipeline.run` can now optionally return provenance data
- experiment runner updated to use the new return value

### Changes
- add `return_provenance` parameter to `Pipeline.run`
- use returned provenance when running experiment conditions

### Testing & Verification
- `pixi run lint`
- `pixi run test`


------
https://chatgpt.com/codex/tasks/task_e_68744efa6ee083299fdf0c97337ea3fa