### PR TITLE
Fix parallel provenance

### DIFF
--- a/crystallize/core/pipeline.py
+++ b/crystallize/core/pipeline.py
@@ -118,7 +118,8 @@ class Pipeline:
                 }
             )
 
-        self._provenance = tuple(MappingProxyType(p) for p in provenance)
+        final_provenance = tuple(MappingProxyType(p) for p in provenance)
+        self._provenance = final_provenance
 
         hit_count = sum(1 for p in provenance if p["cache_hit"])
         logger.info(
@@ -129,7 +130,7 @@ class Pipeline:
         )
 
         if return_provenance:
-            return data, list(self._provenance)
+            return data, list(final_provenance)
         return data
 
 


### PR DESCRIPTION
### Summary

Fixes incorrect provenance when replicates run in parallel.

### Changes

- return the collected provenance directly from `Pipeline.run`
- keep rich tree output stable for parallel runs

### Testing & Verification

- `pixi run lint`
- `pixi run test`
- `pixi run python -m examples.minimal_experiment.main`

------
https://chatgpt.com/codex/tasks/task_e_68747891df14832999f7aa6e52cbc399