### PR TITLE
Implement Artifact Management System

### DIFF
--- a/crystallize/__init__.py
+++ b/crystallize/__init__.py
@@ -9,11 +9,11 @@ from .core import (
     hypothesis,
     pipeline,
     pipeline_step,
-    verifier,
     treatment,
+    verifier,
 )
-from .core.plugins import BasePlugin, LoggingPlugin, SeedPlugin
-from .core.execution import SerialExecution, ParallelExecution
+from .core.execution import ParallelExecution, SerialExecution
+from .core.plugins import ArtifactPlugin, BasePlugin, LoggingPlugin, SeedPlugin
 
 __all__ = [
     "pipeline_step",
@@ -29,4 +29,5 @@ __all__ = [
     "ParallelExecution",
     "SeedPlugin",
     "LoggingPlugin",
+    "ArtifactPlugin",
 ]

--- a/crystallize/core/artifacts.py
+++ b/crystallize/core/artifacts.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class Artifact:
+    """Simple container for artifact data."""
+
+    name: str
+    data: bytes
+    step_name: str
+
+
+class ArtifactLog:
+    """In-memory log of artifacts for the current step."""
+
+    def __init__(self) -> None:
+        self._items: List[Artifact] = []
+
+    def add(self, name: str, data: bytes) -> None:
+        self._items.append(Artifact(name=name, data=data, step_name=""))
+
+    def clear(self) -> None:
+        self._items.clear()
+
+    def __iter__(self):
+        return iter(self._items)
+
+    def __len__(self) -> int:
+        return len(self._items)

--- a/crystallize/core/context.py
+++ b/crystallize/core/context.py
@@ -4,6 +4,8 @@ from collections import defaultdict
 from types import MappingProxyType
 from typing import Any, DefaultDict, Dict, List, Mapping, Optional, Tuple
 
+from .artifacts import ArtifactLog
+
 
 class ContextMutationError(Exception):
     """Raised when attempting to mutate an existing key in FrozenContext."""
@@ -33,6 +35,7 @@ class FrozenContext:
     def __init__(self, initial: Mapping[str, Any]) -> None:
         self._data = copy.deepcopy(dict(initial))
         self.metrics = FrozenMetrics()
+        self.artifacts = ArtifactLog()
 
     def __getitem__(self, key: str) -> Any:
         return copy.deepcopy(self._data[key])

--- a/docs/src/content/docs/how-to/artifacts.md
+++ b/docs/src/content/docs/how-to/artifacts.md
@@ -1,0 +1,35 @@
+---
+title: Saving Artifacts
+description: Persist models, plots, or other files produced during pipeline steps.
+---
+
+Crystallize steps can produce files like trained models or plots. Use `ArtifactPlugin` to automatically save these artifacts to a structured directory.
+
+## 1. Enable the Plugin
+
+```python
+from crystallize.core.plugins import ArtifactPlugin
+from crystallize.core.experiment import Experiment
+from crystallize.core.pipeline import Pipeline
+from crystallize.core.pipeline_step import PipelineStep
+
+class ModelStep(PipelineStep):
+    def __call__(self, data, ctx):
+        ctx.artifacts.add("model.bin", b"binary data")
+        return data
+
+    @property
+    def params(self):
+        return {}
+
+exp = Experiment(
+    datasource=my_source(),
+    pipeline=Pipeline([ModelStep()]),
+    plugins=[ArtifactPlugin(root_dir="artifacts", versioned=True)],
+)
+exp.validate()
+exp.run()
+```
+
+Artifacts are stored under:
+`<root>/<experiment_id>/v<run>/<replicate>/<condition>/<step>/<name>`.

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+
+from crystallize.core.cache import compute_hash
+from crystallize.core.context import FrozenContext
+from crystallize.core.datasource import DataSource
+from crystallize.core.experiment import Experiment
+from crystallize.core.pipeline import Pipeline
+from crystallize.core.pipeline_step import PipelineStep
+from crystallize.core.plugins import ArtifactPlugin
+
+
+class DummySource(DataSource):
+    def fetch(self, ctx: FrozenContext):
+        return 0
+
+
+class LogStep(PipelineStep):
+    def __call__(self, data, ctx):
+        ctx.artifacts.add("out.txt", b"hello")
+        return {"result": data}
+
+    @property
+    def params(self):
+        return {}
+
+
+class CheckStep(PipelineStep):
+    def __init__(self, log_counts):
+        self.log_counts = log_counts
+
+    def __call__(self, data, ctx):
+        self.log_counts.append(len(ctx.artifacts))
+        return {"result": data}
+
+    @property
+    def params(self):
+        return {}
+
+
+def test_artifacts_saved_and_cleared(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    logs = []
+    pipeline = Pipeline([LogStep(), CheckStep(logs)])
+    ds = DummySource()
+    plugin = ArtifactPlugin(root_dir=str(tmp_path / "arts"))
+    exp = Experiment(datasource=ds, pipeline=pipeline, plugins=[plugin])
+    exp.validate()
+    exp.run()
+
+    exp_id = compute_hash(pipeline.signature())
+    expected = (
+        tmp_path
+        / "arts"
+        / exp_id
+        / "v0"
+        / "replicate_0"
+        / "baseline"
+        / "LogStep"
+        / "out.txt"
+    )
+    assert expected.read_text() == "hello"
+    assert logs == [0]
+
+
+def test_artifact_versioning(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    pipeline = Pipeline([LogStep()])
+    ds = DummySource()
+    plugin = ArtifactPlugin(root_dir=str(tmp_path / "arts"), versioned=True)
+    exp = Experiment(datasource=ds, pipeline=pipeline, plugins=[plugin])
+    exp.validate()
+    exp.run()
+    exp.run()
+
+    exp_id = compute_hash(pipeline.signature())
+    path0 = (
+        tmp_path
+        / "arts"
+        / exp_id
+        / "v0"
+        / "replicate_0"
+        / "baseline"
+        / "LogStep"
+        / "out.txt"
+    )
+    path1 = (
+        tmp_path
+        / "arts"
+        / exp_id
+        / "v1"
+        / "replicate_0"
+        / "baseline"
+        / "LogStep"
+        / "out.txt"
+    )
+    assert path0.exists() and path1.exists()


### PR DESCRIPTION
### Summary

Adds a plugin-based artifact management system allowing pipeline steps to save files to disk. Includes documentation and tests.

### Changes

- Introduced `Artifact` and `ArtifactLog` for in-memory artifact tracking.
- `FrozenContext` now exposes `ctx.artifacts` for steps to log artifacts.
- Added `ArtifactPlugin` which saves logged artifacts in a structured directory and supports versioning.
- Exported `ArtifactPlugin` from the public API.
- Added new how-to guide for using artifacts.
- Added tests covering artifact saving and versioning.

### Testing & Verification

- `pixi run lint`
- `pixi run test`


------
https://chatgpt.com/codex/tasks/task_e_6874a1eb74988329b3f4ea6ccd08a399