### PR TITLE
Add Ollama client extra

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -100,6 +100,7 @@ export default defineConfig({
           items: [
             { label: 'RayExecution', slug: 'extras/ray' },
             { label: 'vLLM Engine', slug: 'extras/vllm' },
+            { label: 'Ollama Client', slug: 'extras/ollama' },
           ],
         },
         {

--- a/docs/src/content/docs/extras/ollama.md
+++ b/docs/src/content/docs/extras/ollama.md
@@ -1,0 +1,28 @@
+---
+title: Ollama Client Initialization
+description: Pipeline step for creating an Ollama client
+---
+
+The `initialize_ollama_client` step creates an `ollama.Client` instance and stores it in the experiment context.
+
+## Installation
+
+```bash
+pip install crystallize-extras[ollama]
+```
+
+## Usage
+
+```python
+from crystallize_extras.ollama_step.initialize import initialize_ollama_client
+
+```
+
+Add the step to your pipeline:
+
+```python
+step = initialize_ollama_client(base_url="http://localhost:11434")
+pipeline = Pipeline([step, ...])
+```
+
+The client is stored under the key `ollama_client` by default, but you can customize this with the `context_key` parameter.

--- a/extras/crystallize-extras/crystallize_extras/__init__.py
+++ b/extras/crystallize-extras/crystallize_extras/__init__.py
@@ -1,6 +1,7 @@
 """Optional plugins and utilities for Crystallize."""
 
+from .ollama_step.initialize import initialize_ollama_client
 from .ray_plugin.execution import RayExecution
 from .vllm_step.initialize import initialize_llm_engine
 
-__all__ = ["RayExecution", "initialize_llm_engine"]
+__all__ = ["RayExecution", "initialize_llm_engine", "initialize_ollama_client"]

--- a/extras/crystallize-extras/crystallize_extras/ollama_step/__init__.py
+++ b/extras/crystallize-extras/crystallize_extras/ollama_step/__init__.py
@@ -1,0 +1,3 @@
+from .initialize import initialize_ollama_client as initialize_ollama_client
+
+__all__ = ["initialize_ollama_client"]

--- a/extras/crystallize-extras/crystallize_extras/ollama_step/initialize.py
+++ b/extras/crystallize-extras/crystallize_extras/ollama_step/initialize.py
@@ -1,0 +1,45 @@
+from typing import Any
+
+from crystallize.core.context import FrozenContext
+from crystallize.core.pipeline_step import PipelineStep
+
+try:
+    from ollama import Client
+except ImportError:  # pragma: no cover - optional dependency
+    Client = None
+
+
+class InitializeOllamaClient(PipelineStep):
+    """Pipeline step that initializes an Ollama client during setup."""
+
+    cacheable = False
+
+    def __init__(self, *, base_url: str, context_key: str = "ollama_client") -> None:
+        self.base_url = base_url
+        self.context_key = context_key
+
+    def __call__(self, data: Any, ctx: FrozenContext) -> Any:
+        return data
+
+    @property
+    def params(self) -> dict:
+        return {"base_url": self.base_url, "context_key": self.context_key}
+
+    def setup(self, ctx: FrozenContext) -> None:
+        if Client is None:
+            raise ImportError(
+                "The 'ollama' package is required. Please install with: pip install crystallize-extras[ollama]"
+            )
+        self.client = Client(base_url=self.base_url)
+        ctx.add(self.context_key, self.client)
+
+    def teardown(self, ctx: FrozenContext) -> None:
+        if hasattr(self, "client"):
+            del self.client
+
+
+def initialize_ollama_client(
+    *, base_url: str, context_key: str = "ollama_client"
+) -> InitializeOllamaClient:
+    """Factory function returning :class:`InitializeOllamaClient`."""
+    return InitializeOllamaClient(base_url=base_url, context_key=context_key)

--- a/extras/crystallize-extras/pyproject.toml
+++ b/extras/crystallize-extras/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 [project.optional-dependencies]
 ray = ["ray"]
 vllm = ["vllm"]
+ollama = ["ollama"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/extras/crystallize-extras/tests/test_ollama_step.py
+++ b/extras/crystallize-extras/tests/test_ollama_step.py
@@ -1,0 +1,36 @@
+import pytest
+from crystallize_extras.ollama_step.initialize import initialize_ollama_client
+
+from crystallize.core.context import FrozenContext
+
+
+class DummyClient:
+    def __init__(self, *, base_url: str):
+        self.base_url = base_url
+
+
+def test_initialize_ollama_client_adds_client(monkeypatch):
+    monkeypatch.setattr(
+        "crystallize_extras.ollama_step.initialize.Client",
+        DummyClient,
+    )
+    ctx = FrozenContext({})
+    step = initialize_ollama_client(base_url="http://localhost")
+    step.setup(ctx)
+    assert "ollama_client" in ctx.as_dict()
+    assert isinstance(ctx.as_dict()["ollama_client"], DummyClient)
+    assert ctx.as_dict()["ollama_client"].base_url == "http://localhost"
+    result = step(None, ctx)
+    assert result is None
+    step.teardown(ctx)
+    assert not hasattr(step, "client")
+
+
+def test_initialize_ollama_client_missing_dependency(monkeypatch):
+    from crystallize_extras import ollama_step
+
+    monkeypatch.setattr(ollama_step.initialize, "Client", None)
+    ctx = FrozenContext({})
+    step = ollama_step.initialize.initialize_ollama_client(base_url="http://loc")
+    with pytest.raises(ImportError):
+        step.setup(ctx)


### PR DESCRIPTION
### Summary
Adds a new extra for initializing an Ollama client.

### Changes
- new `initialize_ollama_client` pipeline step and tests
- documentation for the Ollama extra and sidebar entry
- optional `ollama` dependency in extras package

### Testing & Verification
- `pixi run lint`
- `pixi run test`


------
https://chatgpt.com/codex/tasks/task_e_687976a4f7e48329aa059de394f432f9