### PR TITLE
feat(crystallize-ml): apply uses full lifecycle

### DIFF
--- a/docs/src/content/docs/how-to/customizing-experiments.md
+++ b/docs/src/content/docs/how-to/customizing-experiments.md
@@ -63,7 +63,7 @@ After choosing a treatment, you can pass new data through the pipeline:
 result = exp.apply(treatment_name="treatment_a", data=my_data, seed=123)
 ```
 
-`apply()` runs until the first `exit_step` in the pipeline and returns the data at that point. The optional `seed` is forwarded to the experiment's `seed_fn`; if omitted, the experiment's stored seed is not used. This is handy for debugging or production inference once your treatment is validated.
+`apply()` runs until the first `exit_step` in the pipeline, executing plugin hooks and calling step `setup`/`teardown` just like `run`. The optional `seed` is forwarded to the experiment's `seed_fn`; if omitted, the experiment's stored seed is not used. This is handy for debugging or production inference once your treatment is validated.
 
 ## Troubleshooting & FAQs
 

--- a/docs/src/content/docs/reference/experiment.md
+++ b/docs/src/content/docs/reference/experiment.md
@@ -55,8 +55,9 @@ apply(
 ) → Any
 ```
 
-Run the pipeline once and return the output. Plugin hooks are executed and all steps run their
-``setup`` and ``teardown`` methods. Execution stops at the first ``exit_step``.
+Run the pipeline once and return the output. 
+
+This method mirrors :meth:`run` for a single replicate. Plugin hooks are executed and all pipeline steps receive ``setup`` and ``teardown`` calls. Execution stops at the first step marked with :func:`~crystallize.core.pipeline_step.exit_step`. 
 
 ---
 

--- a/docs/src/content/docs/reference/experiment.md
+++ b/docs/src/content/docs/reference/experiment.md
@@ -55,7 +55,8 @@ apply(
 ) → Any
 ```
 
-Run the pipeline once with optional treatment and return outputs. 
+Run the pipeline once and return the output. Plugin hooks are executed and all steps run their
+``setup`` and ``teardown`` methods. Execution stops at the first ``exit_step``.
 
 ---
 

--- a/docs/src/content/docs/tutorials/full-workflow.md
+++ b/docs/src/content/docs/tutorials/full-workflow.md
@@ -114,7 +114,7 @@ Finally, reuse the same experiment and treatment for a one-off inference run.
 output = exp.apply(treatment=best_treatment)
 ```
 
-`apply()` runs the pipeline once (stopping at the `exit_step`) and returns the final output. This mirrors using your tuned configuration in production.
+`apply()` runs the pipeline once (stopping at the `exit_step`), executing plugin hooks and step setup/teardown, then returns the final output. This mirrors using your tuned configuration in production.
 
 ---
 

--- a/docs/src/content/docs/tutorials/optimization.md
+++ b/docs/src/content/docs/tutorials/optimization.md
@@ -110,5 +110,5 @@ Use `apply()` to run the pipeline once with the optimized parameters:
 output = exp.apply(treatment=best)
 ```
 
-This final step mirrors the real-world rollout of the chosen configuration.
+This final step mirrors the real-world rollout of the chosen configuration. `apply()` triggers plugin hooks and step setup/teardown so the run behaves like a single replicate of `run()`.
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1647,8 +1647,8 @@ packages:
   timestamp: 1751491581502
 - pypi: ./extras/crystallize-extras
   name: crystallize-extras
-  version: 0.1.1
-  sha256: 912aaedc46e2f9c03acd920fcf5411af362b6c8d4f46998aa58023dcb08bc7da
+  version: 0.2.0
+  sha256: 4decae4b578af210c09b55ace61cd81c306535f0d1610d6ab1679892a5e398a6
   requires_dist:
   - crystallize-ml
   - ray ; extra == 'ray'


### PR DESCRIPTION
### Summary
- extend `Experiment.apply` to execute plugin hooks and step setup/teardown
- document new behavior in tutorials and how-to guides
- update API reference for `Experiment.apply`
- add tests for lifecycle behavior and seeding

### Changes
- lifecycle support within `.apply`
- docs mention plugin hooks for `apply`
- new unit tests covering apply lifecycle

### Testing & Verification
- `pixi run lint`
- `pixi run test`


------
https://chatgpt.com/codex/tasks/task_e_6879d0f581dc832999d47b800f5ac1a2