### PR TITLE
feat: add ResourceHandle and improve step init

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -19,9 +19,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: prefix-dev/setup-pixi@v0.8.11
-
-      - name: Regenerate lock file
-        run: pixi lock
+        with:
+          pixi-version: v0.49.0
+          locked: false
 
       - name: Install dependencies
         run: pixi install -e dev
@@ -32,7 +32,7 @@ jobs:
       - name: Create Pull Request if changes
         uses: peter-evans/create-pull-request@v7 # Reliable action for auto-PR
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_DOCS_PAT }}
           commit-message: 'docs: auto-update generated API docs'
           title: 'Auto-update generated API docs'
           body: 'This PR auto-generates and updates the API documentation Markdown files based on the latest code changes.'

--- a/crystallize/core/__init__.py
+++ b/crystallize/core/__init__.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Mapping, Optional, Union, Sequence
 from .context import FrozenContext
 from .datasource import DataSource
 from .execution import ParallelExecution, SerialExecution
+from .resources import ResourceHandle
 from .experiment import Experiment
 from .hypothesis import Hypothesis
 from .injection import inject_from_ctx
@@ -212,6 +213,7 @@ __all__ = [
     "ParallelExecution",
     "Pipeline",
     "PipelineStep",
+    "ResourceHandle",
     "Result",
     "SeedPlugin",
     "SerialExecution",

--- a/crystallize/core/experiment.py
+++ b/crystallize/core/experiment.py
@@ -299,7 +299,6 @@ class Experiment:
         for plugin in self.plugins:
             plugin.before_run(self)
 
-        self._setup_ctx = FrozenContext({})
         try:
             for step in self.pipeline.steps:
                 step.setup(self._setup_ctx)
@@ -440,7 +439,6 @@ class Experiment:
                 continue
             plugin.before_run(self)
 
-        self._setup_ctx = FrozenContext({})
         try:
             for step in self.pipeline.steps:
                 step.setup(self._setup_ctx)

--- a/crystallize/core/resources.py
+++ b/crystallize/core/resources.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import threading
+from typing import Any, Callable, Dict
+
+
+_local_storage = threading.local()
+
+
+class ResourceHandle:
+    """A picklable handle for a resource that should be instantiated once per process."""
+
+    def __init__(self, factory: Callable[[], Any], resource_id: str) -> None:
+        self._factory = factory
+        self._resource_id = resource_id
+
+    @property
+    def resource(self) -> Any:
+        """Get or create the resource instance for the current thread/process."""
+        if not hasattr(_local_storage, "resource_cache"):
+            _local_storage.resource_cache = {}
+
+        if self._resource_id not in _local_storage.resource_cache:
+            _local_storage.resource_cache[self._resource_id] = self._factory()
+
+        return _local_storage.resource_cache[self._resource_id]
+
+    def __getstate__(self) -> Dict[str, Any]:
+        """Prepare the handle for pickling by storing the factory and ID."""
+        return {"factory": self._factory, "resource_id": self._resource_id}
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        """Restore the handle after unpickling."""
+        self._factory = state["factory"]
+        self._resource_id = state["resource_id"]

--- a/pixi.lock
+++ b/pixi.lock
@@ -1647,8 +1647,8 @@ packages:
   timestamp: 1751491581502
 - pypi: ./extras/crystallize-extras
   name: crystallize-extras
-  version: 0.2.0
-  sha256: 4decae4b578af210c09b55ace61cd81c306535f0d1610d6ab1679892a5e398a6
+  version: 0.2.1
+  sha256: d4e88ed51b30f92166ca776b5a7ca216a034e0c797ba120743fb43545bd33b62
   requires_dist:
   - crystallize-ml
   - ray ; extra == 'ray'


### PR DESCRIPTION
### Summary
Adds a picklable `ResourceHandle` utility to create resources lazily in each process. The experiment setup context now persists across runs and apply calls. Ollama and vLLM initializers store resource handles rather than raw clients.

### Changes
- Added `ResourceHandle` class and exported through `core.__init__`
- Removed redundant `_setup_ctx` re-initialization in `Experiment`
- Refactored Ollama and vLLM initializer steps to use `ResourceHandle`
- Updated associated tests for new behaviour

### Testing & Verification
- `pixi run lint`
- `pixi run test`


------
https://chatgpt.com/codex/tasks/task_e_6879e033d5808329956ab359f71ce046