### PR TITLE
Remove exit_step and update apply

### DIFF
--- a/crystallize/core/__init__.py
+++ b/crystallize/core/__init__.py
@@ -15,7 +15,7 @@ from .hypothesis import Hypothesis
 from .injection import inject_from_ctx
 from .optimizers import BaseOptimizer, Objective
 from .pipeline import Pipeline
-from .pipeline_step import PipelineStep, exit_step
+from .pipeline_step import PipelineStep
 from .plugins import ArtifactPlugin, BasePlugin, LoggingPlugin, SeedPlugin
 from .result import Result
 from .treatment import Treatment
@@ -224,6 +224,5 @@ __all__ = [
     "data_source",
     "verifier",
     "pipeline",
-    "exit_step",
     "inject_from_ctx",
 ]

--- a/crystallize/core/pipeline_step.py
+++ b/crystallize/core/pipeline_step.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, Tuple, Union
+from typing import Any
 
 from crystallize.core.cache import compute_hash
 from crystallize.core.context import FrozenContext
@@ -48,41 +48,3 @@ class PipelineStep(ABC):
 
         payload = {"class": self.__class__.__name__, "params": self.params}
         return compute_hash(payload)
-
-
-def exit_step(
-    item: Union[
-        PipelineStep,
-        Callable[..., PipelineStep],
-        Tuple[Callable[..., PipelineStep], Dict[str, Any]],
-    ],
-) -> Union[PipelineStep, Callable[..., PipelineStep]]:
-    """Mark a :class:`PipelineStep` as the final step of a pipeline.
-
-    This helper accepts an already constructed step, a factory callable or a
-    ``(factory, params)`` tuple as produced by :func:`pipeline_step`.  The
-    returned object behaves identically to the input but is annotated with the
-    ``is_exit_step`` attribute so that :meth:`Experiment.apply` knows when to
-    stop execution.
-    """
-    if isinstance(item, PipelineStep):
-        setattr(item, "is_exit_step", True)
-        return item
-    elif isinstance(item, tuple):  # From param
-        factory, fixed_kwargs = item
-
-        def wrapped_factory(**extra_kwargs: Any) -> PipelineStep:
-            inst = factory(**{**fixed_kwargs, **extra_kwargs})
-            setattr(inst, "is_exit_step", True)
-            return inst
-
-        return wrapped_factory
-    elif callable(item):  # Plain factory
-
-        def wrapped_factory(**kwargs: Any) -> PipelineStep:
-            inst = item(**kwargs)
-            setattr(inst, "is_exit_step", True)
-            return inst
-
-        return wrapped_factory
-    raise TypeError(f"Invalid item for exit_step: {type(item).__name__}")

--- a/docs/src/content/docs/glossary.md
+++ b/docs/src/content/docs/glossary.md
@@ -30,10 +30,6 @@ def csv_source(ctx: FrozenContext, path: str) -> list:
 The core class orchestrates baseline and treatment runs across replicates, followed by hypothesis verification. Configure it directly with your datasource, pipeline, treatments, hypotheses, replicates, and a list of plugins. Use `run()` for full execution or `apply()` for single-condition inference.
 
 
-## Exit Step
-
-A pipeline step marked with `exit_step()` that terminates pipeline execution early, useful for production inference to skip metric computation. Multiple exit steps halt at the first encountered.
-
 ## FrozenContext
 
 An immutable dictionary-like object for passing parameters during execution. Supports safe addition of new keys via `add(key, value)` but raises `ContextMutationError` on existing key mutations. Includes a `metrics` attribute for accumulating results.

--- a/docs/src/content/docs/how-to/customizing-experiments.md
+++ b/docs/src/content/docs/how-to/customizing-experiments.md
@@ -63,11 +63,10 @@ After choosing a treatment, you can pass new data through the pipeline:
 result = exp.apply(treatment_name="treatment_a", data=my_data, seed=123)
 ```
 
-`apply()` runs until the first `exit_step` in the pipeline, executing plugin hooks and calling step `setup`/`teardown` just like `run`. The optional `seed` is forwarded to the experiment's `seed_fn`; if omitted, the experiment's stored seed is not used. This is handy for debugging or production inference once your treatment is validated.
+`apply()` runs the entire pipeline once, executing plugin hooks and calling step `setup`/`teardown` just like `run`. The optional `seed` is forwarded to the experiment's `seed_fn`; if omitted, the experiment's stored seed is not used. This is handy for debugging or production inference once your treatment is validated.
 
 ## Troubleshooting & FAQs
 
-- **`ValueError: Pipeline must contain an exit_step`** – `.apply()` requires at least one `exit_step` to know where to stop.
 - **`Unknown treatment`** – The name passed to `treatment_name` must match a treatment in the experiment.
 - **Parallelism slower?** – Use `process` executors for CPU-bound work and ensure steps release the GIL for threads.
 

--- a/docs/src/content/docs/reference/experiment.md
+++ b/docs/src/content/docs/reference/experiment.md
@@ -55,9 +55,9 @@ apply(
 ) → Any
 ```
 
-Run the pipeline once and return the output. 
+Run the pipeline once and return the output.
 
-This method mirrors :meth:`run` for a single replicate. Plugin hooks are executed and all pipeline steps receive ``setup`` and ``teardown`` calls. Execution stops at the first step marked with :func:`~crystallize.core.pipeline_step.exit_step`. 
+This method mirrors :meth:`run` for a single replicate. Plugin hooks are executed and all pipeline steps receive ``setup`` and ``teardown`` calls. The pipeline executes fully and the final output is returned.
 
 ---
 

--- a/docs/src/content/docs/reference/pipeline_step.md
+++ b/docs/src/content/docs/reference/pipeline_step.md
@@ -11,20 +11,6 @@ title: Pipeline_step
 
 ---
 
-## <kbd>function</kbd> `exit_step`
-
-```python
-exit_step(
-    item: Union[crystallize.core.pipeline_step.PipelineStep, Callable[..., crystallize.core.pipeline_step.PipelineStep], Tuple[Callable[..., crystallize.core.pipeline_step.PipelineStep], Dict[str, Any]]]
-) → Union[crystallize.core.pipeline_step.PipelineStep, Callable[..., crystallize.core.pipeline_step.PipelineStep]]
-```
-
-Mark a :class:`PipelineStep` as the final step of a pipeline. 
-
-This helper accepts an already constructed step, a factory callable or a ``(factory, params)`` tuple as produced by :func:`pipeline_step`.  The returned object behaves identically to the input but is annotated with the ``is_exit_step`` attribute so that :meth:`Experiment.apply` knows when to stop execution. 
-
-
----
 
 ## <kbd>class</kbd> `PipelineStep`
 

--- a/docs/src/content/docs/tutorials/full-workflow.md
+++ b/docs/src/content/docs/tutorials/full-workflow.md
@@ -19,7 +19,7 @@ First create the core experiment that stays fixed across all stages.
 from crystallize import data_source, pipeline_step
 from crystallize.core.context import FrozenContext
 from crystallize.core.pipeline import Pipeline
-from crystallize.core.pipeline_step import exit_step
+
 from crystallize.core.experiment import Experiment
 import random
 
@@ -40,7 +40,7 @@ def record_sum(data: list[int], ctx: FrozenContext) -> list[int]:
     ctx.metrics.add("total", sum(data))
     return data
 
-pipeline = Pipeline([add_delta(), add_noise(), exit_step(record_sum())])
+pipeline = Pipeline([add_delta(), add_noise(), record_sum()])
 datasource = numbers()
 exp = Experiment(datasource=datasource, pipeline=pipeline)
 exp.validate()
@@ -114,7 +114,7 @@ Finally, reuse the same experiment and treatment for a one-off inference run.
 output = exp.apply(treatment=best_treatment)
 ```
 
-`apply()` runs the pipeline once (stopping at the `exit_step`), executing plugin hooks and step setup/teardown, then returns the final output. This mirrors using your tuned configuration in production.
+`apply()` runs the pipeline once, executing plugin hooks and step setup/teardown, then returns the final output. This mirrors using your tuned configuration in production.
 
 ---
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,7 +5,7 @@ import pytest
 from crystallize.core.context import FrozenContext
 from crystallize.core.exceptions import PipelineExecutionError
 from crystallize.core.pipeline import Pipeline
-from crystallize.core.pipeline_step import PipelineStep, exit_step
+from crystallize.core.pipeline_step import PipelineStep
 
 
 class AddStep(PipelineStep):
@@ -59,7 +59,7 @@ def test_pipeline_execution_error():
 
 
 def test_pipeline_exit_step_mid_chain():
-    pipeline = Pipeline([AddStep(1), exit_step(AddStep(2)), MetricsStep()])
+    pipeline = Pipeline([AddStep(1), AddStep(2), MetricsStep()])
     ctx = FrozenContext({})
     result = pipeline.run(0, ctx)
     assert result == {"result": 3}


### PR DESCRIPTION
### Summary
- remove `exit_step` and associated logic
- execute full pipeline in `Experiment.apply`
- auto-set replicates to 1 in `apply`
- update docs/examples accordingly
- adjust tests to match new behavior

### Changes
- deleted `exit_step` helper
- `Experiment.apply` always runs all steps and sets replicates from datasource
- cleaned documentation to drop mentions of `exit_step`
- updated tutorial and customization guide
- refactored tests

### Testing & Verification
- `pixi run --no-lockfile-update lint`
- `pixi run --no-lockfile-update test`


------
https://chatgpt.com/codex/tasks/task_e_687a149e184083299041b2fc24a1dd57