### PR TITLE
Document Result.print_tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ result = experiment.run(
 )
 print(result.metrics)
 print(result.hypothesis_result)
+result.print_tree()
 ```
 
 ### Project Structure

--- a/crystallize/experiments/result.py
+++ b/crystallize/experiments/result.py
@@ -7,6 +7,7 @@ from .result_structs import ExperimentMetrics, HypothesisResult
 
 class Result:
     """Outputs of an experiment run including metrics and provenance."""
+
     def __init__(
         self,
         metrics: ExperimentMetrics,
@@ -33,7 +34,28 @@ class Result:
 
     # ------------------------------------------------------------------ #
     def print_tree(self, fmt: str = "treatment > replicate > step") -> None:
-        """Print a tree summary of execution provenance."""
+        """Print a color-coded tree of execution provenance.
+
+        The ``fmt`` string controls the hierarchy of the output.  Valid tokens
+        are ``"treatment"``, ``"replicate"``, ``"step"`` and ``"action"``.  When
+        ``"action"`` is included as the final element, each step lists the
+        values read, metrics written and context mutations that occurred.
+
+        The function uses :mod:`rich` to render a pretty tree if the package is
+        installed; otherwise a plain-text version is printed.
+
+        Parameters
+        ----------
+        fmt:
+            Format specification controlling how provenance records are grouped.
+            The default groups by treatment, replicate and step.
+
+        Raises
+        ------
+        ValueError
+            If the format specification contains unknown tokens or ``"action"``
+            is not the final element.
+        """
         tokens = [t.strip().lower() for t in fmt.split(">")]
         valid = {"treatment", "replicate", "step", "action"}
         if any(tok not in valid for tok in tokens):
@@ -79,7 +101,7 @@ class Result:
 
         root = Node("Experiment Summary", "bold")
 
-        color_order = ['bold yellow', 'green', 'cyan']
+        color_order = ["bold yellow", "green", "cyan"]
 
         def get_color(token: str) -> str:
             return color_order[tokens.index(token)]
@@ -88,7 +110,7 @@ class Result:
             "treatment": get_color("treatment"),
             "replicate": get_color("replicate"),
             "step": get_color("step"),
-        }        
+        }
 
         def add_actions(parent: Node, acts: Dict[str, Any]) -> None:
             mapping = {

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -46,6 +46,10 @@ export default defineConfig({
               label: 'Chaining Experiments with a DAG',
               slug: 'how-to/dag-experiments',
             },
+            {
+              label: 'Viewing Provenance',
+              slug: 'how-to/view-provenance',
+            },
           ],
         },
         {

--- a/docs/src/content/docs/how-to/view-provenance.md
+++ b/docs/src/content/docs/how-to/view-provenance.md
@@ -1,0 +1,29 @@
+---
+title: Viewing Provenance with Result.print_tree
+description: Use Result.print_tree to inspect context changes and cache activity.
+---
+
+Crystallize records every context mutation during an experiment run. The
+:class:`~crystallize.experiments.result.Result` object exposes a handy
+:meth:`print_tree` method to visualize this provenance as a tree.
+
+## Example
+
+```python
+result = experiment.run(treatments=[my_treatment], hypotheses=[my_hypothesis])
+result.print_tree()  # shows treatments, replicates and steps
+```
+
+By default the tree groups by treatment, replicate and step. Pass a custom
+format string to reorder the hierarchy or include ``"action"`` to display reads
+and writes:
+
+```python
+result.print_tree("replicate > step > action")
+```
+
+When the optional ``rich`` package is installed, the output is colorized for
+clarity. Otherwise a plain text tree is printed.
+
+Use this method whenever you want a quick snapshot of what happened during a
+run—it's especially useful for debugging cached pipeline steps.

--- a/docs/src/content/docs/reference/result.md
+++ b/docs/src/content/docs/reference/result.md
@@ -61,6 +61,10 @@ Return the :class:`HypothesisResult` with ``name`` if present.
 print_tree(fmt: 'str' = 'treatment > replicate > step') → None
 ```
 
-Print a tree summary of execution provenance. 
+Print a color-coded tree of execution provenance. The ``fmt`` string controls
+the hierarchy and may include ``"treatment"``, ``"replicate"``, ``"step`` and
+``"action"``. When ``"action"`` is present as the final token, each step lists
+the context reads, writes and metric updates. Uses ``rich`` for color if
+installed.
 
 


### PR DESCRIPTION
### Summary
- expand `Result.print_tree` docstring
- mention provenance tree in README quick example
- add how-to guide for printing provenance
- update sidebar and reference docs

### Changes
- docstring for `Result.print_tree`
- README example now shows `result.print_tree()`
- new doc: `view-provenance.md`
- sidebar updated for the new doc

### Testing & Verification
- `ruff check crystallize tests`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dc4dce0e08329b150ecd6d27169f1