### PR TITLE
Add Output artifacts and resume strategy

### DIFF
--- a/crystallize/__init__.py
+++ b/crystallize/__init__.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from crystallize.experiments.experiment_graph import ExperimentGraph
 from crystallize.experiments.experiment import Experiment
-from crystallize.datasources.datasource import DataSource, MultiArtifactDataSource
-from crystallize.datasources import Output
+from crystallize.datasources.datasource import DataSource, ExperimentInput
+from crystallize.datasources import Artifact
 from crystallize.experiments.treatment import Treatment
 from crystallize.utils.context import FrozenContext
 from crystallize.utils.decorators import (
@@ -41,7 +41,7 @@ __all__ = [
     "LoggingPlugin",
     "ArtifactPlugin",
     "ExperimentGraph",
-    "MultiArtifactDataSource",
-    "Output",
+    "Artifact",
+    "ExperimentInput",
 ]
 

--- a/crystallize/__init__.py
+++ b/crystallize/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from crystallize.experiments.experiment_graph import ExperimentGraph
 from crystallize.experiments.experiment import Experiment
 from crystallize.datasources.datasource import DataSource, MultiArtifactDataSource
+from crystallize.datasources import Output
 from crystallize.experiments.treatment import Treatment
 from crystallize.utils.context import FrozenContext
 from crystallize.utils.decorators import (
@@ -41,5 +42,6 @@ __all__ = [
     "ArtifactPlugin",
     "ExperimentGraph",
     "MultiArtifactDataSource",
+    "Output",
 ]
 

--- a/crystallize/datasources/__init__.py
+++ b/crystallize/datasources/__init__.py
@@ -1,3 +1,3 @@
-from .artifacts import ArtifactLog
+from .artifacts import ArtifactLog, Output
 
-__all__ = ["ArtifactLog"]
+__all__ = ["ArtifactLog", "Output"]

--- a/crystallize/datasources/__init__.py
+++ b/crystallize/datasources/__init__.py
@@ -1,3 +1,3 @@
-from .artifacts import ArtifactLog, Output
+from .artifacts import ArtifactLog, Artifact
 
-__all__ = ["ArtifactLog", "Output"]
+__all__ = ["ArtifactLog", "Artifact"]

--- a/crystallize/datasources/artifacts.py
+++ b/crystallize/datasources/artifacts.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional, TYPE_CHECKING
+
+from crystallize.utils.exceptions import ContextMutationError
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from crystallize.utils.context import FrozenContext
 
 
 @dataclass
@@ -18,6 +23,7 @@ class ArtifactLog:
 
     def __init__(self) -> None:
         self._items: List[Artifact] = []
+        self._names: set[str] = set()
 
     def add(self, name: str, data: bytes) -> None:
         """Append a new artifact to the log.
@@ -26,11 +32,17 @@ class ArtifactLog:
             name: Filename for the artifact.
             data: Raw bytes to be written to disk by ``ArtifactPlugin``.
         """
+        if name in self._names:
+            raise ContextMutationError(
+                f"Artifact '{name}' already written in this run"
+            )
+        self._names.add(name)
         self._items.append(Artifact(name=name, data=data, step_name=""))
 
     def clear(self) -> None:
         """Remove all logged artifacts."""
         self._items.clear()
+        self._names.clear()
 
     def __iter__(self):
         """Iterate over collected artifacts."""
@@ -39,3 +51,21 @@ class ArtifactLog:
     def __len__(self) -> int:
         """Return the number of stored artifacts."""
         return len(self._items)
+
+
+class Output:
+    """Declarative handle for a file artifact."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._ctx: Optional["FrozenContext"] = None
+
+    def _clone_with_context(self, ctx: "FrozenContext") -> "Output":
+        clone = Output(self.name)
+        clone._ctx = ctx
+        return clone
+
+    def write(self, data: bytes) -> None:
+        if self._ctx is None:
+            raise RuntimeError("Output not bound to context")
+        self._ctx.artifacts.add(self.name, data)

--- a/crystallize/datasources/artifacts.py
+++ b/crystallize/datasources/artifacts.py
@@ -15,6 +15,7 @@ from crystallize.datasources.datasource import DataSource
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from crystallize.utils.context import FrozenContext
+    from crystallize.experiments.experiment import Experiment
 
 
 @dataclass

--- a/crystallize/datasources/artifacts.py
+++ b/crystallize/datasources/artifacts.py
@@ -1,16 +1,24 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional, TYPE_CHECKING
+import json
+from pathlib import Path
+from typing import Any, Callable, List, Optional, TYPE_CHECKING
 
 from crystallize.utils.exceptions import ContextMutationError
+from crystallize.utils.constants import (
+    METADATA_FILENAME,
+    BASELINE_CONDITION,
+)
+from crystallize.plugins.plugins import ArtifactPlugin
+from crystallize.datasources.datasource import DataSource
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from crystallize.utils.context import FrozenContext
 
 
 @dataclass
-class Artifact:
+class ArtifactRecord:
     """Container representing a file-like artifact produced by a step."""
 
     name: str
@@ -22,7 +30,7 @@ class ArtifactLog:
     """Collect artifacts produced during a pipeline step."""
 
     def __init__(self) -> None:
-        self._items: List[Artifact] = []
+        self._items: List[ArtifactRecord] = []
         self._names: set[str] = set()
 
     def add(self, name: str, data: bytes) -> None:
@@ -37,7 +45,7 @@ class ArtifactLog:
                 f"Artifact '{name}' already written in this run"
             )
         self._names.add(name)
-        self._items.append(Artifact(name=name, data=data, step_name=""))
+        self._items.append(ArtifactRecord(name=name, data=data, step_name=""))
 
     def clear(self) -> None:
         """Remove all logged artifacts."""
@@ -53,19 +61,64 @@ class ArtifactLog:
         return len(self._items)
 
 
-class Output:
-    """Declarative handle for a file artifact."""
+class Artifact(DataSource):
+    """Declarative handle for reading and writing artifacts."""
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, loader: Callable[[Path], Any] | None = None) -> None:
         self.name = name
+        self.loader = loader or (lambda p: p.read_bytes())
         self._ctx: Optional["FrozenContext"] = None
+        self._producer: Optional["Experiment"] = None
+        self._manifest: Optional[dict[str, str]] = None
+        self.replicates: int | None = None
 
-    def _clone_with_context(self, ctx: "FrozenContext") -> "Output":
-        clone = Output(self.name)
+    def _clone_with_context(self, ctx: "FrozenContext") -> "Artifact":
+        clone = Artifact(self.name, loader=self.loader)
         clone._ctx = ctx
+        clone._producer = self._producer
+        clone._manifest = self._manifest
+        clone.replicates = self.replicates
         return clone
 
     def write(self, data: bytes) -> None:
         if self._ctx is None:
-            raise RuntimeError("Output not bound to context")
+            raise RuntimeError("Artifact not bound to context")
         self._ctx.artifacts.add(self.name, data)
+
+    def _base_dir(self) -> Path:
+        if self._producer is None:
+            raise RuntimeError("Artifact not attached to an Experiment")
+        plugin = self._producer.get_plugin(ArtifactPlugin)
+        if plugin is None:
+            raise RuntimeError("ArtifactPlugin required to load artifacts")
+        return Path(plugin.root_dir) / (self._producer.name or self._producer.id) / f"v{plugin.version}"
+
+    def _load_manifest(self) -> None:
+        if self._manifest is not None:
+            return
+        base = self._base_dir()
+        path = base / "_manifest.json"
+        if path.exists():
+            with open(path) as f:
+                self._manifest = json.load(f)
+        else:
+            self._manifest = {}
+
+    def fetch(self, ctx: "FrozenContext") -> Any:
+        self._load_manifest()
+        base = self._base_dir()
+        if self.replicates is None:
+            meta_path = base / METADATA_FILENAME
+            if meta_path.exists():
+                with open(meta_path) as f:
+                    meta = json.load(f)
+                self.replicates = meta.get("replicates")
+        step_name = self._manifest.get(self.name)
+        if step_name is None:
+            raise FileNotFoundError(f"Manifest missing entry for {self.name}")
+        rep = ctx.get("replicate", 0)
+        cond = ctx.get("condition", BASELINE_CONDITION)
+        path = base / f"replicate_{rep}" / cond / step_name / self.name
+        if not path.exists():
+            raise FileNotFoundError(f"Artifact {path} not found")
+        return self.loader(path)

--- a/crystallize/datasources/datasource.py
+++ b/crystallize/datasources/datasource.py
@@ -1,15 +1,18 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-from crystallize.utils.context import FrozenContext
-from .artifacts import Artifact
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from crystallize.utils.context import FrozenContext
+    from .artifacts import Artifact
 
 
 class DataSource(ABC):
     """Abstract provider of input data for an experiment."""
 
     @abstractmethod
-    def fetch(self, ctx: FrozenContext) -> Any:
+    def fetch(self, ctx: "FrozenContext") -> Any:
         """Return raw data for a single pipeline run.
 
         Implementations may load data from disk, generate synthetic samples or
@@ -36,7 +39,7 @@ class ExperimentInput(DataSource):
         self._replicates = getattr(first, "replicates", None)
         self.required_outputs = list(inputs.values())
 
-    def fetch(self, ctx: FrozenContext) -> dict[str, Any]:
+    def fetch(self, ctx: "FrozenContext") -> dict[str, Any]:
         return {name: art.fetch(ctx) for name, art in self._inputs.items()}
 
     @property

--- a/crystallize/datasources/datasource.py
+++ b/crystallize/datasources/datasource.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from crystallize.utils.context import FrozenContext
+from .artifacts import Artifact
 
 
 class DataSource(ABC):
@@ -24,22 +25,24 @@ class DataSource(ABC):
         raise NotImplementedError()
 
 
-class MultiArtifactDataSource(DataSource):
-    """Aggregate multiple artifact datasources into one."""
+class ExperimentInput(DataSource):
+    """Load multiple named artifacts for an experiment."""
 
-    def __init__(self, **kwargs: DataSource) -> None:
-        if not kwargs:
-            raise ValueError("At least one datasource must be provided")
-        self._sources = kwargs
-        first = next(iter(kwargs.values()))
+    def __init__(self, **inputs: "Artifact") -> None:
+        if not inputs:
+            raise ValueError("At least one input must be provided")
+        self._inputs = inputs
+        first = next(iter(inputs.values()))
         self._replicates = getattr(first, "replicates", None)
-        self.required_outputs = []
-        for src in kwargs.values():
-            self.required_outputs.extend(getattr(src, "required_outputs", []))
+        self.required_outputs = list(inputs.values())
 
     def fetch(self, ctx: FrozenContext) -> dict[str, Any]:
-        return {name: src.fetch(ctx) for name, src in self._sources.items()}
+        return {name: art.fetch(ctx) for name, art in self._inputs.items()}
 
     @property
     def replicates(self) -> int | None:
         return self._replicates
+
+
+# Backwards compatibility
+MultiArtifactDataSource = ExperimentInput

--- a/crystallize/datasources/datasource.py
+++ b/crystallize/datasources/datasource.py
@@ -33,6 +33,9 @@ class MultiArtifactDataSource(DataSource):
         self._sources = kwargs
         first = next(iter(kwargs.values()))
         self._replicates = getattr(first, "replicates", None)
+        self.required_outputs = []
+        for src in kwargs.values():
+            self.required_outputs.extend(getattr(src, "required_outputs", []))
 
     def fetch(self, ctx: FrozenContext) -> dict[str, Any]:
         return {name: src.fetch(ctx) for name, src in self._sources.items()}

--- a/crystallize/experiments/experiment.py
+++ b/crystallize/experiments/experiment.py
@@ -239,6 +239,7 @@ class Experiment:
         class ArtifactDataSource(DataSource):
             def __init__(self) -> None:
                 self.replicates = replicates
+                self.required_outputs = [Output(name)]
 
             def fetch(self, ctx: FrozenContext) -> Any:
                 rep = ctx.get("replicate", 0)

--- a/crystallize/experiments/experiment.py
+++ b/crystallize/experiments/experiment.py
@@ -17,7 +17,7 @@ from typing import (
 )
 
 from crystallize.utils.context import FrozenContext
-from crystallize.datasources import Output
+from crystallize.datasources import Artifact
 from crystallize.datasources.datasource import DataSource
 from crystallize.plugins.execution import VALID_EXECUTOR_TYPES, SerialExecution
 from crystallize.experiments.hypothesis import Hypothesis
@@ -78,7 +78,7 @@ class Experiment:
         *,
         name: str | None = None,
         initial_ctx: Dict[str, Any] | None = None,
-        outputs: List[Output] | None = None,
+        outputs: List[Artifact] | None = None,
     ) -> None:
         """Instantiate an experiment configuration.
 
@@ -92,7 +92,10 @@ class Experiment:
         self.pipeline = pipeline
         self.name = name
         self.id: Optional[str] = None
-        self.outputs = outputs or []
+        outputs = outputs or []
+        self.outputs: Dict[str, Artifact] = {a.name: a for a in outputs}
+        for a in outputs:
+            a._producer = self
 
         self._setup_ctx = FrozenContext({})
         if initial_ctx:
@@ -239,7 +242,7 @@ class Experiment:
         class ArtifactDataSource(DataSource):
             def __init__(self) -> None:
                 self.replicates = replicates
-                self.required_outputs = [Output(name)]
+                self.required_outputs = [Artifact(name)]
 
             def fetch(self, ctx: FrozenContext) -> Any:
                 rep = ctx.get("replicate", 0)

--- a/crystallize/experiments/experiment_graph.py
+++ b/crystallize/experiments/experiment_graph.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 from typing import Dict, List
+from pathlib import Path
+
+from crystallize.plugins.plugins import ArtifactPlugin
+from crystallize.utils.constants import BASELINE_CONDITION
 
 import networkx as nx
 
@@ -42,6 +46,7 @@ class ExperimentGraph:
         self,
         treatments: List[Treatment] | None = None,
         replicates: int | None = None,
+        strategy: str = "rerun",
     ) -> Dict[str, Result]:
         """Execute all experiments respecting dependency order."""
         if not nx.is_directed_acyclic_graph(self._graph):
@@ -52,10 +57,22 @@ class ExperimentGraph:
 
         for name in order:
             exp: Experiment = self._graph.nodes[name]["experiment"]
+            if strategy == "resume":
+                plugin = exp.get_plugin(ArtifactPlugin)
+                if plugin is not None:
+                    base = Path(plugin.root_dir) / (exp.name or exp.id) / "v0"
+                    all_done = True
+                    for cond in [BASELINE_CONDITION] + [t.name for t in exp.treatments]:
+                        if not (base / cond / ".crystallize_complete").exists():
+                            all_done = False
+                            break
+                    if all_done:
+                        continue
             result = exp.run(
                 treatments=treatments,
                 hypotheses=getattr(exp, "hypotheses", []),
                 replicates=replicates or getattr(exp, "replicates", 1),
+                strategy=strategy,
             )
             self._results[name] = result
 

--- a/crystallize/experiments/experiment_graph.py
+++ b/crystallize/experiments/experiment_graph.py
@@ -78,7 +78,7 @@ class ExperimentGraph:
                             req_names = {r.name for r in reqs}
                             if not req_names:
                                 continue
-                            if not req_names.issubset({o.name for o in exp.outputs}):
+                            if not req_names.issubset(set(exp.outputs)):
                                 continue
                             for out_name in req_names:
                                 if not list(base.rglob(out_name)):

--- a/crystallize/plugins/plugins.py
+++ b/crystallize/plugins/plugins.py
@@ -6,7 +6,7 @@ import os
 from abc import ABC
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Mapping
 
 from crystallize.utils.constants import (
     REPLICATE_KEY,
@@ -234,3 +234,14 @@ class ArtifactPlugin(BasePlugin):
         os.makedirs(base, exist_ok=True)
         with open(base / METADATA_FILENAME, "w") as f:
             json.dump(meta, f)
+
+        def dump_condition(name: str, metrics: Mapping[str, Any]) -> None:
+            dest = base / name
+            os.makedirs(dest, exist_ok=True)
+            with open(dest / "results.json", "w") as f:
+                json.dump({"metrics": metrics}, f)
+            open(dest / ".crystallize_complete", "a").close()
+
+        dump_condition(BASELINE_CONDITION, result.metrics.baseline.metrics)
+        for t_name, m in result.metrics.treatments.items():
+            dump_condition(t_name, m.metrics)

--- a/crystallize/utils/context.py
+++ b/crystallize/utils/context.py
@@ -5,12 +5,7 @@ from types import MappingProxyType
 from typing import Any, DefaultDict, Dict, List, Mapping, Optional, Tuple
 
 from crystallize.datasources.artifacts import ArtifactLog
-
-
-class ContextMutationError(Exception):
-    """Raised when attempting to mutate an existing key in FrozenContext."""
-
-    pass
+from crystallize.utils.exceptions import ContextMutationError
 
 
 class FrozenMetrics:

--- a/crystallize/utils/decorators.py
+++ b/crystallize/utils/decorators.py
@@ -15,7 +15,7 @@ from crystallize.utils.constants import (
     SEED_USED_KEY,
 )
 from crystallize.utils.context import FrozenContext
-from crystallize.datasources.datasource import DataSource, MultiArtifactDataSource
+from crystallize.datasources.datasource import DataSource, ExperimentInput
 from crystallize.plugins.execution import ParallelExecution, SerialExecution
 from crystallize.experiments.experiment import Experiment
 from crystallize.experiments.experiment_graph import ExperimentGraph
@@ -233,7 +233,7 @@ __all__ = [
     "BasePlugin",
     "BaseOptimizer",
     "DataSource",
-    "MultiArtifactDataSource",
+    "ExperimentInput",
     "Experiment",
     "ExperimentGraph",
     "FrozenContext",

--- a/crystallize/utils/exceptions.py
+++ b/crystallize/utils/exceptions.py
@@ -15,3 +15,7 @@ class PipelineExecutionError(CrystallizeError):
     def __init__(self, step_name: str, original_exception: Exception) -> None:
         super().__init__(f"Step '{step_name}' failed: {str(original_exception)}")
         self.original_exception = original_exception
+
+
+class ContextMutationError(CrystallizeError):
+    """Raised when attempting to mutate frozen context."""

--- a/crystallize/utils/injection.py
+++ b/crystallize/utils/injection.py
@@ -5,6 +5,7 @@ from functools import wraps
 from typing import Any, Callable
 
 from .context import FrozenContext
+from crystallize.datasources import Output
 
 
 def inject_from_ctx(fn: Callable[..., Any]) -> Callable[..., Any]:
@@ -38,6 +39,10 @@ def inject_from_ctx(fn: Callable[..., Any]) -> Callable[..., Any]:
                 else:
                     value = value()
             bound.arguments[name] = value
+
+        for name, val in list(bound.arguments.items()):
+            if isinstance(val, Output) and getattr(val, "_ctx", None) is None:
+                bound.arguments[name] = val._clone_with_context(ctx)
         return fn(*bound.args, **bound.kwargs)
 
     return wrapper

--- a/crystallize/utils/injection.py
+++ b/crystallize/utils/injection.py
@@ -5,7 +5,7 @@ from functools import wraps
 from typing import Any, Callable
 
 from .context import FrozenContext
-from crystallize.datasources import Output
+from crystallize.datasources import Artifact
 
 
 def inject_from_ctx(fn: Callable[..., Any]) -> Callable[..., Any]:
@@ -41,7 +41,7 @@ def inject_from_ctx(fn: Callable[..., Any]) -> Callable[..., Any]:
             bound.arguments[name] = value
 
         for name, val in list(bound.arguments.items()):
-            if isinstance(val, Output) and getattr(val, "_ctx", None) is None:
+            if isinstance(val, Artifact) and getattr(val, "_ctx", None) is None:
                 bound.arguments[name] = val._clone_with_context(ctx)
         return fn(*bound.args, **bound.kwargs)
 

--- a/docs/src/content/docs/how-to/artifacts.md
+++ b/docs/src/content/docs/how-to/artifacts.md
@@ -8,13 +8,13 @@ Crystallize steps can produce files like trained models or plots. Use `ArtifactP
 ## 1. Enable the Plugin
 
 ```python
-from crystallize import Experiment, Pipeline, Output
+from crystallize import Experiment, Pipeline, Artifact
 from crystallize.pipelines.pipeline_step import PipelineStep
 from crystallize.plugins.plugins import ArtifactPlugin
 
 
 class ModelStep(PipelineStep):
-    def __init__(self, out: Output):
+    def __init__(self, out: Artifact):
         self.out = out
 
     def __call__(self, data, ctx):
@@ -25,7 +25,7 @@ class ModelStep(PipelineStep):
     def params(self):
         return {}
 
-out = Output("model.bin")
+out = Artifact("model.bin")
 exp = Experiment(
     datasource=my_source(),
     pipeline=Pipeline([ModelStep(out)]),

--- a/docs/src/content/docs/how-to/artifacts.md
+++ b/docs/src/content/docs/how-to/artifacts.md
@@ -8,24 +8,29 @@ Crystallize steps can produce files like trained models or plots. Use `ArtifactP
 ## 1. Enable the Plugin
 
 ```python
-from crystallize import Experiment, Pipeline
+from crystallize import Experiment, Pipeline, Output
 from crystallize.pipelines.pipeline_step import PipelineStep
 from crystallize.plugins.plugins import ArtifactPlugin
 
 
 class ModelStep(PipelineStep):
+    def __init__(self, out: Output):
+        self.out = out
+
     def __call__(self, data, ctx):
-        ctx.artifacts.add("model.bin", b"binary data")
+        self.out.write(b"binary data")
         return data
 
     @property
     def params(self):
         return {}
 
+out = Output("model.bin")
 exp = Experiment(
     datasource=my_source(),
-    pipeline=Pipeline([ModelStep()]),
+    pipeline=Pipeline([ModelStep(out)]),
     plugins=[ArtifactPlugin(root_dir="artifacts", versioned=True)],
+    outputs=[out],
 )
 exp.validate()
 exp.run()
@@ -90,3 +95,10 @@ exp_csv = Experiment(
 
 Set `require_metadata=True` when you want to ensure metadata exists and raise
 an error if the previous run lacked `ArtifactPlugin`.
+
+## Resuming Experiments
+
+Artifacts also enable resuming long experiments. Pass `strategy="resume"` to
+`Experiment.run()` or `ExperimentGraph.run()` and Crystallize will skip any
+conditions that already wrote a completion marker. Downstream experiments are
+rerun only when their required outputs are missing.

--- a/docs/src/content/docs/how-to/custom-steps.md
+++ b/docs/src/content/docs/how-to/custom-steps.md
@@ -55,7 +55,7 @@ parameters. Examples include:
 
 - reading ``ctx.get('replicate')`` to know the current replicate number
 - recording metrics with ``ctx.metrics.add()``
-- saving files or other artifacts via ``ctx.artifacts.add()``
+- saving files or other artifacts via ``Output.write()``
 
 Use parameter injection for simple values and fall back to ``ctx`` for these
 framework features.

--- a/docs/src/content/docs/how-to/custom-steps.md
+++ b/docs/src/content/docs/how-to/custom-steps.md
@@ -55,7 +55,7 @@ parameters. Examples include:
 
 - reading ``ctx.get('replicate')`` to know the current replicate number
 - recording metrics with ``ctx.metrics.add()``
-- saving files or other artifacts via ``Output.write()``
+- saving files or other artifacts via ``Artifact.write()``
 
 Use parameter injection for simple values and fall back to ``ctx`` for these
 framework features.

--- a/docs/src/content/docs/how-to/dag-experiments.md
+++ b/docs/src/content/docs/how-to/dag-experiments.md
@@ -1,6 +1,6 @@
 ---
 title: Chaining Experiments with a DAG
-description: Use ExperimentGraph and MultiArtifactDataSource to link multiple experiments together.
+description: Use ExperimentGraph and ExperimentInput to link multiple experiments together.
 ---
 
 Crystallize can orchestrate complex workflows by chaining experiments in a directed acyclic graph (DAG). Upstream experiments generate artifacts that downstream ones consume.
@@ -22,12 +22,12 @@ Running `graph.run()` executes experiments in topological order.
 
 ## 2. Consume Multiple Artifacts
 
-Combine outputs from several experiments using `MultiArtifactDataSource`:
+Combine outputs from several experiments using `ExperimentInput`:
 
 ```python
-from crystallize import MultiArtifactDataSource
+from crystallize import ExperimentInput
 
-ds = MultiArtifactDataSource(
+ds = ExperimentInput(
     first=exp_a.artifact_datasource(step="StepA", name="output.json"),
     second=exp_b.artifact_datasource(step="StepB", name="output.json"),
 )

--- a/docs/src/content/docs/reference/datasource.md
+++ b/docs/src/content/docs/reference/datasource.md
@@ -44,13 +44,13 @@ Implementations may load data from disk, generate synthetic samples or access re
 
 ---
 
-## <kbd>class</kbd> `MultiArtifactDataSource`
-Aggregate multiple artifact datasources into one. 
+## <kbd>class</kbd> `ExperimentInput`
+Load multiple named artifacts for an experiment.
 
-### <kbd>method</kbd> `MultiArtifactDataSource.__init__`
+### <kbd>method</kbd> `ExperimentInput.__init__`
 
 ```python
-__init__(**kwargs: crystallize.core.datasource.DataSource) → None
+__init__(**inputs: crystallize.core.datasource.DataSource) → None
 ```
 
 
@@ -60,7 +60,7 @@ __init__(**kwargs: crystallize.core.datasource.DataSource) → None
 
 ---
 
-#### <kbd>property</kbd> MultiArtifactDataSource.replicates
+#### <kbd>property</kbd> ExperimentInput.replicates
 
 
 
@@ -70,7 +70,7 @@ __init__(**kwargs: crystallize.core.datasource.DataSource) → None
 
 ---
 
-### <kbd>method</kbd> `MultiArtifactDataSource.fetch`
+### <kbd>method</kbd> `ExperimentInput.fetch`
 
 ```python
 fetch(ctx: crystallize.core.context.FrozenContext) → dict[str, Any]

--- a/examples/artifact_chaining/experiment1.py
+++ b/examples/artifact_chaining/experiment1.py
@@ -1,4 +1,4 @@
-from crystallize import data_source, pipeline_step
+from crystallize import data_source, pipeline_step, Output
 from crystallize import Experiment
 from crystallize.pipelines.pipeline import Pipeline
 from crystallize.plugins.plugins import ArtifactPlugin
@@ -8,18 +8,20 @@ def source(ctx):
     return [1, 2, 3]
 
 @pipeline_step()
-def save_data(data, ctx):
+def save_data(data, ctx, out: Output):
     import pandas as pd
 
     df = pd.DataFrame({"values": data})
     csv = df.to_csv(index=False).encode()
-    ctx.artifacts.add("data.csv", csv)
+    out.write(csv)
     return data
 
+out_file = Output("data.csv")
 exp1 = Experiment(
     datasource=source(),
-    pipeline=Pipeline([save_data()]),
+    pipeline=Pipeline([save_data(out=out_file)]),
     plugins=[ArtifactPlugin(root_dir="artifact_chain", versioned=True)],
+    outputs=[out_file],
 )
 exp1.validate()
 

--- a/examples/artifact_chaining/experiment1.py
+++ b/examples/artifact_chaining/experiment1.py
@@ -1,4 +1,4 @@
-from crystallize import data_source, pipeline_step, Output
+from crystallize import data_source, pipeline_step, Artifact
 from crystallize import Experiment
 from crystallize.pipelines.pipeline import Pipeline
 from crystallize.plugins.plugins import ArtifactPlugin
@@ -8,7 +8,7 @@ def source(ctx):
     return [1, 2, 3]
 
 @pipeline_step()
-def save_data(data, ctx, out: Output):
+def save_data(data, ctx, out: Artifact):
     import pandas as pd
 
     df = pd.DataFrame({"values": data})
@@ -16,7 +16,7 @@ def save_data(data, ctx, out: Output):
     out.write(csv)
     return data
 
-out_file = Output("data.csv")
+out_file = Artifact("data.csv")
 exp1 = Experiment(
     datasource=source(),
     pipeline=Pipeline([save_data(out=out_file)]),

--- a/examples/dag_experiment/main.py
+++ b/examples/dag_experiment/main.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from crystallize import data_source, pipeline_step, Output
+from crystallize import data_source, pipeline_step, Artifact
 from crystallize import (
     ArtifactPlugin,
     Experiment,
     ExperimentGraph,
-    MultiArtifactDataSource,
+    ExperimentInput,
     Pipeline,
     Treatment,
     FrozenContext,
@@ -28,7 +28,7 @@ def humidities(ctx: FrozenContext) -> list[float]:
 
 
 @pipeline_step()
-def average(data: list[float], ctx: FrozenContext, out: Output) -> float:
+def average(data: list[float], ctx: FrozenContext, out: Artifact) -> float:
     """Compute the average value adjusted by a ``factor`` parameter."""
     factor = ctx.get("factor", 1.0)
     avg = sum(data) / len(data) * factor
@@ -48,7 +48,7 @@ def comfort_index(data: dict[str, Path], ctx: FrozenContext) -> float:
     return index
 
 
-out_temp = Output("average.json")
+out_temp = Artifact("average.json")
 temp_exp = Experiment(
     datasource=temperatures(),
     pipeline=Pipeline([average(out=out_temp)]),
@@ -58,7 +58,7 @@ temp_exp = Experiment(
 )
 temp_exp.validate()
 
-out_humidity = Output("average.json")
+out_humidity = Artifact("average.json")
 humidity_exp = Experiment(
     datasource=humidities(),
     pipeline=Pipeline([average(out=out_humidity)]),
@@ -68,7 +68,7 @@ humidity_exp = Experiment(
 )
 humidity_exp.validate()
 
-comfort_ds = MultiArtifactDataSource(
+comfort_ds = ExperimentInput(
     temp=temp_exp.artifact_datasource(step="AverageStep", name="average.json"),
     humidity=humidity_exp.artifact_datasource(step="AverageStep", name="average.json"),
 )

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -9,7 +9,7 @@ from crystallize.experiments.experiment import Experiment
 from crystallize.pipelines.pipeline import Pipeline
 from crystallize.pipelines.pipeline_step import PipelineStep
 from crystallize.plugins.plugins import ArtifactPlugin
-from crystallize.datasources import Output, ArtifactLog
+from crystallize.datasources import Artifact, ArtifactLog
 from crystallize.utils.context import ContextMutationError
 
 
@@ -190,7 +190,7 @@ def test_output_write_and_injection(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     class WriteStep(PipelineStep):
-        def __init__(self, out: Output) -> None:
+        def __init__(self, out: Artifact) -> None:
             self.out = out
 
         def __call__(self, data, ctx):
@@ -201,7 +201,7 @@ def test_output_write_and_injection(tmp_path: Path, monkeypatch):
         def params(self):
             return {}
 
-    out = Output("x.txt")
+    out = Artifact("x.txt")
     pipeline = Pipeline([WriteStep(out)])
     exp = Experiment(
         datasource=DummySource(),

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -9,6 +9,8 @@ from crystallize.experiments.experiment import Experiment
 from crystallize.pipelines.pipeline import Pipeline
 from crystallize.pipelines.pipeline_step import PipelineStep
 from crystallize.plugins.plugins import ArtifactPlugin
+from crystallize.datasources import Output, ArtifactLog
+from crystallize.utils.context import ContextMutationError
 
 
 class DummySource(DataSource):
@@ -182,3 +184,39 @@ def test_artifact_datasource_require_metadata(tmp_path: Path, monkeypatch):
 
     with pytest.raises(FileNotFoundError):
         exp1.artifact_datasource(step="LogStep", name="out.txt", require_metadata=True)
+
+
+def test_output_write_and_injection(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    class WriteStep(PipelineStep):
+        def __init__(self, out: Output) -> None:
+            self.out = out
+
+        def __call__(self, data, ctx):
+            self.out.write(b"data")
+            return data
+
+        @property
+        def params(self):
+            return {}
+
+    out = Output("x.txt")
+    pipeline = Pipeline([WriteStep(out)])
+    exp = Experiment(
+        datasource=DummySource(),
+        pipeline=pipeline,
+        plugins=[ArtifactPlugin(root_dir=str(tmp_path / "arts"))],
+        outputs=[out],
+    )
+    exp.validate()
+    exp.run()
+    path = tmp_path / "arts" / exp.id / "v0" / "baseline" / "results.json"
+    assert path.exists()
+
+
+def test_artifact_log_write_once():
+    log = ArtifactLog()
+    log.add("a.txt", b"1")
+    with pytest.raises(ContextMutationError):
+        log.add("a.txt", b"2")

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -15,7 +15,7 @@ from crystallize.utils.cache import compute_hash
 from crystallize.utils.context import FrozenContext
 from crystallize.datasources.datasource import DataSource
 from crystallize.experiments.experiment import Experiment
-from crystallize.datasources import Output
+from crystallize.datasources import Artifact
 from crystallize.experiments.hypothesis import Hypothesis
 from crystallize.pipelines.pipeline import Pipeline
 from crystallize.pipelines.pipeline_step import PipelineStep
@@ -1026,7 +1026,7 @@ def test_experiment_resume_skips(tmp_path: Path, monkeypatch):
         datasource=DummyDataSource(),
         pipeline=pipeline,
         plugins=[plugin],
-        outputs=[Output("x.txt")],
+        outputs=[Artifact("x.txt")],
     )
     exp.validate()
     exp.run()
@@ -1037,7 +1037,7 @@ def test_experiment_resume_skips(tmp_path: Path, monkeypatch):
         datasource=DummyDataSource(),
         pipeline=Pipeline([step2]),
         plugins=[plugin],
-        outputs=[Output("x.txt")],
+        outputs=[Artifact("x.txt")],
     )
     exp2.validate()
     exp2.run(strategy="resume")

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -2,6 +2,7 @@ import random
 import time
 import threading
 from typing import Any, List
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -14,6 +15,7 @@ from crystallize.utils.cache import compute_hash
 from crystallize.utils.context import FrozenContext
 from crystallize.datasources.datasource import DataSource
 from crystallize.experiments.experiment import Experiment
+from crystallize.datasources import Output
 from crystallize.experiments.hypothesis import Hypothesis
 from crystallize.pipelines.pipeline import Pipeline
 from crystallize.pipelines.pipeline_step import PipelineStep
@@ -999,3 +1001,44 @@ def test_apply_seed_plugin_autoseed():
     exp.validate()
     exp.apply(data=1)
     assert called == [hash(7)]
+
+
+def test_experiment_resume_skips(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    class CountStep(PipelineStep):
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __call__(self, data, ctx):
+            self.calls += 1
+            ctx.metrics.add("metric", data)
+            return {"metric": data}
+
+        @property
+        def params(self):
+            return {}
+
+    step = CountStep()
+    pipeline = Pipeline([step])
+    plugin = ArtifactPlugin(root_dir=str(tmp_path / "arts"))
+    exp = Experiment(
+        datasource=DummyDataSource(),
+        pipeline=pipeline,
+        plugins=[plugin],
+        outputs=[Output("x.txt")],
+    )
+    exp.validate()
+    exp.run()
+    assert step.calls == 1
+
+    step2 = CountStep()
+    exp2 = Experiment(
+        datasource=DummyDataSource(),
+        pipeline=Pipeline([step2]),
+        plugins=[plugin],
+        outputs=[Output("x.txt")],
+    )
+    exp2.validate()
+    exp2.run(strategy="resume")
+    assert step2.calls == 0


### PR DESCRIPTION
### Summary
- add `Output` class for writing artifacts safely
- enforce single-write behavior in `ArtifactLog`
- support context-aware cloning via injection
- persist per-condition results in `ArtifactPlugin`
- implement `strategy` parameter for experiments and graphs
- add resume tests and Output usage tests

### Changes
- new Output class with `write()`
- artifacts log tracks names to prevent duplicates
- experiment run can resume using stored results
- experiment graph skips completed experiments when resuming
- plugin writes `results.json` and completion markers

### Testing & Verification
- `pixi run lint`
- `pixi run test`

------
https://chatgpt.com/codex/tasks/task_e_687dceb7b038832989f2d120d24dd821