### PR TITLE
Add automatic ExperimentGraph construction

### DIFF
--- a/docs/src/content/docs/how-to/dag-experiments.md
+++ b/docs/src/content/docs/how-to/dag-experiments.md
@@ -7,15 +7,12 @@ Crystallize can orchestrate complex workflows by chaining experiments in a direc
 
 ## 1. Build a Graph
 
-Use `ExperimentGraph` to register each experiment and declare dependencies:
+Use `ExperimentGraph.from_experiments()` to automatically discover dependencies:
 
 ```python
 from crystallize import ExperimentGraph
 
-graph = ExperimentGraph()
-graph.add_experiment(exp_a)
-graph.add_experiment(exp_b)
-graph.add_dependency(exp_b, exp_a)
+graph = ExperimentGraph.from_experiments([exp_a, exp_b])
 ```
 
 Running `graph.run()` executes experiments in topological order.

--- a/docs/src/content/docs/reference/experiment_graph.md
+++ b/docs/src/content/docs/reference/experiment_graph.md
@@ -44,7 +44,17 @@ Add an edge from ``upstream`` to ``downstream``.
 add_experiment(experiment: 'Experiment') → None
 ```
 
-Add an experiment node to the graph. 
+Add an experiment node to the graph.
+
+---
+
+### <kbd>method</kbd> `ExperimentGraph.from_experiments`
+
+```python
+from_experiments(experiments: List[Experiment]) → ExperimentGraph
+```
+
+Automatically build a dependency graph by inspecting ``ExperimentInput`` objects.
 
 ---
 

--- a/examples/dag_experiment/main.py
+++ b/examples/dag_experiment/main.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from crystallize import data_source, pipeline_step, Artifact
 from crystallize import (
+    Artifact,
     ArtifactPlugin,
     Experiment,
     ExperimentGraph,
     ExperimentInput,
+    FrozenContext,
     Pipeline,
     Treatment,
-    FrozenContext,
+    data_source,
+    pipeline_step,
 )
 
 
@@ -82,11 +84,7 @@ comfort_exp.validate()
 
 
 if __name__ == "__main__":
-    graph = ExperimentGraph()
-    for exp in (temp_exp, humidity_exp, comfort_exp):
-        graph.add_experiment(exp)
-    graph.add_dependency(comfort_exp, temp_exp)
-    graph.add_dependency(comfort_exp, humidity_exp)
+    graph = ExperimentGraph.from_experiments([temp_exp, humidity_exp, comfort_exp])
 
     print("Baseline run:")
     base = graph.run()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import types
 # Provide a minimal networkx stub so tests run without the real dependency
 nx = types.ModuleType("networkx")
 
+
 class DiGraph:
     def __init__(self):
         self._succ = {}
@@ -59,8 +60,36 @@ def topological_sort(g: DiGraph):
 
     return order
 
+
+def weakly_connected_components(g: DiGraph):
+    nodes = set(g.nodes.keys())
+    undirected_adj = {n: set() for n in nodes}
+    for u, neighbors in g._succ.items():
+        for v in neighbors:
+            undirected_adj[u].add(v)
+            undirected_adj[v].add(u)
+
+    visited = set()
+    for node in nodes:
+        if node not in visited:
+            component = set()
+            q = [node]
+            visited.add(node)
+            head = 0
+            while head < len(q):
+                curr = q[head]
+                head += 1
+                component.add(curr)
+                for neighbor in undirected_adj.get(curr, []):
+                    if neighbor not in visited:
+                        visited.add(neighbor)
+                        q.append(neighbor)
+            yield component
+
+
 nx.DiGraph = DiGraph
 nx.is_directed_acyclic_graph = is_directed_acyclic_graph
 nx.topological_sort = topological_sort
+nx.weakly_connected_components = weakly_connected_components
 
 sys.modules.setdefault("networkx", nx)


### PR DESCRIPTION
### Summary
Implement automatic dependency graph construction for Crystallize experiments.

### Changes
- add `ExperimentGraph.from_experiments` factory building and validating graphs
- update example workflow to use new API
- document the new method and update DAG how-to guide
- extend unit tests for automated graph creation

### Testing & Verification
- `pixi run lint` *(fails: command not found)*
- `pixi run test` *(fails: command not found)*
- `pytest` *(fails: missing dependencies)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687de34926808329a3aeb65b46574ffb