### PR TITLE
Fix artifact datasource detection in ExperimentGraph

### DIFF
--- a/crystallize/experiments/experiment_graph.py
+++ b/crystallize/experiments/experiment_graph.py
@@ -56,14 +56,20 @@ class ExperimentGraph:
 
         for exp in experiments:
             ds = exp.datasource
+
+            required_artifacts = []
             if isinstance(ds, ExperimentInput):
-                for art in getattr(ds, "required_outputs", []):
-                    parent = artifact_map.get(art)
-                    if parent is None:
-                        raise ValueError(
-                            f"Artifact '{art.name}' has no producing experiment"
-                        )
-                    graph.add_edge(parent.name, exp.name)
+                required_artifacts = getattr(ds, "required_outputs", [])
+            elif isinstance(ds, Artifact):
+                required_artifacts = [ds]
+
+            for art in required_artifacts:
+                parent = artifact_map.get(art)
+                if parent is None:
+                    raise ValueError(
+                        f"Artifact '{art.name}' has no producing experiment"
+                    )
+                graph.add_edge(parent.name, exp.name)
 
         if not nx.is_directed_acyclic_graph(graph):
             raise ValueError("Experiment graph contains cycles")

--- a/tests/test_experiment_graph.py
+++ b/tests/test_experiment_graph.py
@@ -364,3 +364,28 @@ def test_from_experiments_duplicate_artifact():
 
     with pytest.raises(ValueError, match="multiple experiments"):
         ExperimentGraph.from_experiments([exp_a, exp_b])
+
+
+def test_from_experiments_handles_single_artifact_datasource():
+    """Tests graph builder with datasource as a single Artifact."""
+    out_a = Artifact("a.txt")
+
+    exp_a = Experiment(
+        datasource=DummySource(),
+        pipeline=Pipeline([PassStep()]),
+        name="a",
+        outputs=[out_a],
+    )
+
+    exp_b = Experiment(
+        datasource=exp_a.outputs["a.txt"],
+        pipeline=Pipeline([PassStep()]),
+        name="b",
+    )
+
+    for e in (exp_a, exp_b):
+        e.validate()
+
+    graph = ExperimentGraph.from_experiments([exp_a, exp_b])
+
+    assert "b" in graph._graph._succ.get("a", set())


### PR DESCRIPTION
### Summary
Fix dependency discovery when an Experiment uses a single `Artifact` as its datasource. The old logic only handled `ExperimentInput` and failed to connect such experiments.

### Changes
- generalize dependency detection in `ExperimentGraph.from_experiments`
- add regression test for single artifact datasource case

### Testing & Verification
- `pixi run lint`
- `pixi run test`


------
https://chatgpt.com/codex/tasks/task_e_688045f617948329a71d8f0fccfb77f0