### PR TITLE
Add async __acall__ test

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,4 +1,5 @@
 import pytest
+import asyncio
 
 from crystallize import (
     data_source,
@@ -140,3 +141,20 @@ def test_experiment_runs_with_multiprocessing():
 
     result = exp.run(replicates=2)
     assert result.metrics.baseline.metrics["result"] == [5, 5]
+
+
+@pipeline_step()
+async def async_add(data, ctx, *, delta: int = 0):
+    await asyncio.sleep(0)
+    return data + delta
+
+
+def test_async_acall_injection_and_overrides():
+    ctx = FrozenContext({"delta": 3})
+    step = async_add()
+    result = asyncio.run(step.__acall__(2, ctx))
+    assert result == 5
+
+    step_override = async_add(delta=1)
+    result_override = asyncio.run(step_override.__acall__(2, ctx))
+    assert result_override == 3


### PR DESCRIPTION
### Summary
Adds coverage for the `__acall__` method generated by `pipeline_step`.

### Changes
- new async test in `tests/test_decorators.py`

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_688123bb17508329b6ece5000b84fced