### PR TITLE
Refactor CLI to foundational Textual app

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "networkx >=3.4.2,<4",
     "tqdm",
     "rich >=13.8.1,<14",
-    "simple-term-menu >=1.6.6,<2",
 ]
 
 [project.optional-dependencies]
@@ -28,17 +27,21 @@ dev = []  # Empty; dev deps handled in pixi sections
 extras = ["crystallize-extras"]
 ray = ["ray"]
 vllm = ["vllm"]
+cli = [
+    "textual",
+    "simple-term-menu",
+]
 
 [project.urls]
 Homepage = "https://github.com/brysontang/crystallize"
 Documentation = "https://github.com/brysontang/crystallize/tree/main/docs"
 
 [project.scripts]
-crystallize = "crystallize.cli:run"
+crystallize = "cli.main:run"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["crystallize*"]
+include = ["crystallize*", "cli"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/tests/test_cli_new.py
+++ b/tests/test_cli_new.py
@@ -6,7 +6,7 @@ from crystallize.experiments.experiment import Experiment
 from crystallize.experiments.experiment_graph import ExperimentGraph
 from crystallize.pipelines.pipeline import Pipeline
 
-from crystallize.cli import discover_objects, _run_object
+from cli.main import discover_objects, _run_object
 
 
 @data_source


### PR DESCRIPTION
### Summary
Refactor the old script-based CLI into a new Textual application and adjust project configuration.

### Changes
- removed `crystallize/cli.py` and created `cli/main.py` with the new Textual-based CLI
- added `cli/__init__.py` so the package is discoverable
- updated `pyproject.toml` to register the new entry point, add optional `cli` extras, and include `cli` package
- modified tests to import from the new CLI location

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_68816ee6d8a0832980e0801217d7d015