### PR TITLE
Rebuild interactive CLI with Textual

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -8,9 +8,10 @@ import inspect
 import shutil
 import sys
 from pathlib import Path
-from contextlib import redirect_stdout
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type
 
+
+import networkx as nx
 from rich.table import Table
 from rich.text import Text
 from textual.app import App, ComposeResult
@@ -31,11 +32,11 @@ from textual.widgets import (
 from textual.widgets.selection_list import Selection
 from textual.screen import ModalScreen
 from textual.message import Message
+from textual.reactive import reactive
 
 from crystallize.experiments.experiment import Experiment
 from crystallize.experiments.experiment_graph import ExperimentGraph
 from crystallize.plugins.plugins import ArtifactPlugin
-
 
 OBJ_TYPES = {
     "experiment": Experiment,
@@ -133,6 +134,13 @@ DeleteDataScreen Container {
 SelectionList {
     height: 1fr;
     width: 100%;
+}
+
+#dag-display {
+    height: auto;
+    border: round $primary;
+    padding: 0 1;
+    margin-bottom: 1;
 }
 
 RichLog {
@@ -419,6 +427,12 @@ class StrategyScreen(ModalScreen[str | None]):
 class RunScreen(ModalScreen[None]):
     """A screen to display the live output of a running experiment."""
 
+    class NodeStatusChanged(Message):
+        def __init__(self, node_name: str, status: str) -> None:
+            self.node_name = node_name
+            self.status = status
+            super().__init__()
+
     class ExperimentComplete(Message):
         """Posted when the experiment worker finishes."""
 
@@ -428,56 +442,107 @@ class RunScreen(ModalScreen[None]):
 
     BINDINGS = [("ctrl+c", "cancel_and_exit", "Cancel and Go Back")]
 
+    node_states: dict[str, str] = reactive({})
+
     def __init__(self, obj: Any, strategy: str, replicates: int | None) -> None:
         super().__init__()
         self._obj = obj
         self._strategy = strategy
         self._replicates = replicates
-        self._result: Any = None  # To store the result for the button
+        self._result: Any = None
+        # DO NOT initialize reactive variables here
+
+    def watch_node_states(self) -> None:
+        """Called when the node_states dictionary is updated."""
+        if not isinstance(self._obj, ExperimentGraph):
+            return
+
+        try:
+            dag_widget = self.query_one("#dag-display", Static)
+        except NoMatches:
+            # This can happen if the watcher is triggered before mount.
+            return
+
+        # Build the colored, linear DAG display
+        text = Text(justify="center")
+        order = list(nx.topological_sort(self._obj._graph))
+
+        for i, node in enumerate(order):
+            status = self.node_states.get(node, "pending")
+            style = {
+                "completed": "bold green",
+                "running": "bold blue",
+                "pending": "bold white",
+            }.get(status, "bold white")
+
+            text.append(f"[ {node} ]", style=style)
+            if i < len(order) - 1:
+                text.append(" ⟶  ", style="white")
+
+        dag_widget.update(text)
+
+    def on_node_status_changed(self, message: NodeStatusChanged) -> None:
+        """Update the state of a node."""
+        self.node_states = {**self.node_states, message.node_name: message.status}
 
     def compose(self) -> ComposeResult:
         with VerticalScroll(id="run-container"):
             yield Header(show_clock=True)
             yield Static(f"⚡ Running: {self._obj.name}", id="modal-title")
+            yield Static(id="dag-display", classes="hidden")
             yield RichLog(highlight=True, markup=True, id="live_log")
-            # Add a new "View Summary" button, also hidden
-            yield Button("View Summary", id="view_summary", classes="hidden")
-            yield Button("Close", id="close_run", classes="hidden")
+            yield Button("Close", id="close_run")
 
     def on_mount(self) -> None:
-        # This method can be restored from our last working version
+        # Initialize all nodes to "pending". The backend will update their true status.
+        if isinstance(self._obj, ExperimentGraph):
+            self.node_states = {node: "pending" for node in self._obj._graph.nodes}
+            self.query_one("#dag-display").remove_class("hidden")
+
         log = self.query_one("#live_log", RichLog)
+
+        async def progress_callback(status: str, name: str) -> None:
+            self.app.call_from_thread(
+                self.on_node_status_changed, self.NodeStatusChanged(name, status)
+            )
 
         def run_experiment_sync() -> None:
             original_stdout = sys.stdout
             sys.stdout = WidgetWriter(log, self.app)
             result = None
             try:
-                result = asyncio.run(
-                    _run_object(self._obj, self._strategy, self._replicates)
-                )
+
+                async def run_with_callback():
+                    if isinstance(self._obj, ExperimentGraph):
+                        return await self._obj.arun(
+                            strategy=self._strategy,
+                            replicates=self._replicates,
+                            progress_callback=progress_callback,
+                        )
+                    else:
+                        return await _run_object(
+                            self._obj, self._strategy, self._replicates
+                        )
+
+                result = asyncio.run(run_with_callback())
             except Exception as e:
                 print(f"[bold red]An error occurred in the worker:\n{e}[/bold red]")
             finally:
                 sys.stdout = original_stdout
-
-                self.on_experiment_complete(self.ExperimentComplete(result))
+                self.app.call_from_thread(
+                    self.on_experiment_complete, self.ExperimentComplete(result)
+                )
 
         self.worker = self.run_worker(run_experiment_sync, thread=True)
 
     def on_experiment_complete(self, message: ExperimentComplete) -> None:
         """Called when the ExperimentComplete message is received."""
-        # Store the result so the button's action can use it
         self._result = message.result
         try:
             log = self.query_one("#live_log", RichLog)
-            print(self._result)
             if self._result is not None:
-                # Also write the summary to the main log so it's visible here too
                 _write_summary(log, self._result)
 
-            # Show both buttons
-            self.query_one("#view_summary").remove_class("hidden")
             self.query_one("#close_run").remove_class("hidden")
         except NoMatches:
             pass
@@ -489,14 +554,13 @@ class RunScreen(ModalScreen[None]):
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Handle button presses."""
-        if event.button.id == "view_summary" and self._result is not None:
-            self.app.push_screen(SummaryScreen(self._result))
-        elif event.button.id == "close_run":
+        if event.button.id == "close_run":
             self.app.pop_screen()
 
 
 async def _launch_run(app: App, obj: Any) -> None:
     selected = obj
+    # This should only happen if it's an experiment graph
     if isinstance(selected, ExperimentGraph):
         deletable: List[Tuple[str, Path]] = []
         for node in selected._graph.nodes:

--- a/crystallize/experiments/experiment_graph.py
+++ b/crystallize/experiments/experiment_graph.py
@@ -87,9 +87,10 @@ class ExperimentGraph:
                 "Unused experiments detected: " + ", ".join(str(u) for u in unused)
             )
 
-        # Try to infer a name if not explicitly given, e.g., from the final node
-        final_nodes = [n for n, d in graph.out_degree() if d == 0]
+        # Infer graph name from the “final” experiment(s) — those with no successors
+        final_nodes = [node for node, children in graph._succ.items() if not children]
         graph_name = final_nodes[0] if len(final_nodes) == 1 else "ExperimentGraph"
+
         obj = cls(name=graph_name)
         obj._graph = graph
         return obj

--- a/crystallize/experiments/experiment_graph.py
+++ b/crystallize/experiments/experiment_graph.py
@@ -22,9 +22,10 @@ from .treatment import Treatment
 class ExperimentGraph:
     """Manage and run a directed acyclic graph of experiments."""
 
-    def __init__(self) -> None:
+    def __init__(self, name: str | None = None) -> None:
         self._graph = nx.DiGraph()
         self._results: Dict[str, Result] = {}
+        self._name = name
 
     # ------------------------------------------------------------------ #
     @classmethod
@@ -86,7 +87,10 @@ class ExperimentGraph:
                 "Unused experiments detected: " + ", ".join(str(u) for u in unused)
             )
 
-        obj = cls()
+        # Try to infer a name if not explicitly given, e.g., from the final node
+        final_nodes = [n for n, d in graph.out_degree() if d == 0]
+        graph_name = final_nodes[0] if len(final_nodes) == 1 else "ExperimentGraph"
+        obj = cls(name=graph_name)
         obj._graph = graph
         return obj
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -170,13 +170,16 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/32/da7f44bcb1105d3e88a0b74ebdca50c59121d2ddf71c9e34ba47df7f3a56/keyring-25.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/9e/6b8b057eb511ea904a4fd6a835fee0a87ccb08edd64026e783a3ee6bb8c5/lazydocs-0.4.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/35/137da042dfb4720b638d2937c38a9c2df83fe32d20e8c8f3185dbfef05f7/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/f7/7782a043553ee469c1ff49cfa1cdace2d6bf99a1f333cf38676b3ddf30da/mdit_py_plugins-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2b/9f/7ba6f94fc1e9ac3d2b853fdff3035fb2fa5afbed898c4a72b8a020610594/more_itertools-10.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/2c/6394301428b2017a9d5644af25f487fa557d06bc8a491769accec7524d9a/nh3-0.3.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/56/09/054aea9b7534a15ad38a363a2bd974c20646ab1582a387a95b8df1bfea1c/pkginfo-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6b/4e/1523cb902fd98355e2e9ea5e5eb237cbc5f3ad5f3075fa65087aa0ecb669/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -187,9 +190,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d8/e4/ebe27c54d2534cc41d00ea1d78b783763f97abf3e3d6dd41e5536daa52a5/textual-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/ec/00f9d5fd040ae29867355e559a94e9a8429225a0284a3f5f091a3878bfc0/twine-5.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl
       osx-arm64:
@@ -257,13 +262,16 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/32/da7f44bcb1105d3e88a0b74ebdca50c59121d2ddf71c9e34ba47df7f3a56/keyring-25.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/9e/6b8b057eb511ea904a4fd6a835fee0a87ccb08edd64026e783a3ee6bb8c5/lazydocs-0.4.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/e1/6e2194baeae0bca1fae6629dc0cbbb968d4d941469cbab11a3872edff374/MarkupSafe-3.0.2-cp310-cp310-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/f7/7782a043553ee469c1ff49cfa1cdace2d6bf99a1f333cf38676b3ddf30da/mdit_py_plugins-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2b/9f/7ba6f94fc1e9ac3d2b853fdff3035fb2fa5afbed898c4a72b8a020610594/more_itertools-10.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/e0/cf1543e798ba86d838952e8be4cb8d18e22999be2a24b112a671f1c04fd6/nh3-0.3.0-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/56/09/054aea9b7534a15ad38a363a2bd974c20646ab1582a387a95b8df1bfea1c/pkginfo-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/7a/68bd47624dab8fd4afbfd3c48e3b79efe09098ae941de5b58abcbadff5cb/PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl
@@ -272,9 +280,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d8/e4/ebe27c54d2534cc41d00ea1d78b783763f97abf3e3d6dd41e5536daa52a5/textual-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/ec/00f9d5fd040ae29867355e559a94e9a8429225a0284a3f5f091a3878bfc0/twine-5.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl
       win-64:
@@ -345,13 +355,16 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/32/da7f44bcb1105d3e88a0b74ebdca50c59121d2ddf71c9e34ba47df7f3a56/keyring-25.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/9e/6b8b057eb511ea904a4fd6a835fee0a87ccb08edd64026e783a3ee6bb8c5/lazydocs-0.4.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/06/e7175d06dd6e9172d4a69a72592cb3f7a996a9c396eee29082826449bbc3/MarkupSafe-3.0.2-cp310-cp310-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/f7/7782a043553ee469c1ff49cfa1cdace2d6bf99a1f333cf38676b3ddf30da/mdit_py_plugins-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2b/9f/7ba6f94fc1e9ac3d2b853fdff3035fb2fa5afbed898c4a72b8a020610594/more_itertools-10.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8c/ae/324b165d904dc1672eee5f5661c0a68d4bab5b59fbb07afb6d8d19a30b45/nh3-0.3.0-cp38-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/56/09/054aea9b7534a15ad38a363a2bd974c20646ab1582a387a95b8df1bfea1c/pkginfo-1.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/84/0fa4b06f6d6c958d207620fc60005e241ecedceee58931bb20138e1e5776/PyYAML-6.0.2-cp310-cp310-win_amd64.whl
@@ -361,9 +374,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d8/e4/ebe27c54d2534cc41d00ea1d78b783763f97abf3e3d6dd41e5536daa52a5/textual-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/ec/00f9d5fd040ae29867355e559a94e9a8429225a0284a3f5f091a3878bfc0/twine-5.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl
   extras:
@@ -2937,6 +2952,26 @@ packages:
   purls: []
   size: 55476
   timestamp: 1727963768015
+- pypi: https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl
+  name: linkify-it-py
+  version: 2.0.3
+  sha256: 6bcbc417b0ac14323382aef5c5192c0075bf8a9d6b41820a2b66371eac6b6d79
+  requires_dist:
+  - uc-micro-py
+  - pytest ; extra == 'benchmark'
+  - pytest-benchmark ; extra == 'benchmark'
+  - pre-commit ; extra == 'dev'
+  - isort ; extra == 'dev'
+  - flake8 ; extra == 'dev'
+  - black ; extra == 'dev'
+  - pyproject-flake8 ; extra == 'dev'
+  - sphinx ; extra == 'doc'
+  - sphinx-book-theme ; extra == 'doc'
+  - myst-parser ; extra == 'doc'
+  - pytest ; extra == 'test'
+  - coverage ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/af/80/5a40b9689f17612434b820854cba9b8cabd5142072c491b5280fe5f7a35e/llguidance-0.7.30-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: llguidance
   version: 0.7.30
@@ -3030,6 +3065,20 @@ packages:
   version: 3.0.2
   sha256: 6af100e168aa82a50e186c82875a5893c5597a0c1ccdb0d8b40240b1f28b969a
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/a7/f7/7782a043553ee469c1ff49cfa1cdace2d6bf99a1f333cf38676b3ddf30da/mdit_py_plugins-0.4.2-py3-none-any.whl
+  name: mdit-py-plugins
+  version: 0.4.2
+  sha256: 0c673c3f889399a33b95e88d2f0d111b4447bdfea7f237dab2d488f459835636
+  requires_dist:
+  - markdown-it-py>=1.0.0,<4.0.0
+  - pre-commit ; extra == 'code-style'
+  - myst-parser ; extra == 'rtd'
+  - sphinx-book-theme ; extra == 'rtd'
+  - coverage ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  - pytest-cov ; extra == 'testing'
+  - pytest-regressions ; extra == 'testing'
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
   name: mdurl
   version: 0.1.2
@@ -4031,6 +4080,22 @@ packages:
   - pytest-cov ; extra == 'testing'
   - wheel ; extra == 'testing'
   requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl
+  name: platformdirs
+  version: 4.3.8
+  sha256: ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4
+  requires_dist:
+  - furo>=2024.8.6 ; extra == 'docs'
+  - proselint>=0.14 ; extra == 'docs'
+  - sphinx-autodoc-typehints>=3 ; extra == 'docs'
+  - sphinx>=8.1.3 ; extra == 'docs'
+  - appdirs==1.4.4 ; extra == 'test'
+  - covdefaults>=2.3 ; extra == 'test'
+  - pytest-cov>=6 ; extra == 'test'
+  - pytest-mock>=3.14 ; extra == 'test'
+  - pytest>=8.3.4 ; extra == 'test'
+  - mypy>=1.14.1 ; extra == 'type'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
   sha256: a8eb555eef5063bbb7ba06a379fa7ea714f57d9741fe0efdb9442dbbc2cccbcc
   md5: 7da7ccd349dbf6487a7778579d2bb971
@@ -5963,6 +6028,32 @@ packages:
   purls: []
   size: 151460
   timestamp: 1732982860332
+- pypi: https://files.pythonhosted.org/packages/d8/e4/ebe27c54d2534cc41d00ea1d78b783763f97abf3e3d6dd41e5536daa52a5/textual-4.0.0-py3-none-any.whl
+  name: textual
+  version: 4.0.0
+  sha256: 214051640f890676a670aa7d29cd2a37d27cfe6b2cf866e9d5abc3b6c89c5800
+  requires_dist:
+  - markdown-it-py[linkify,plugins]>=2.1.0
+  - platformdirs>=3.6.0,<5
+  - rich>=13.3.3
+  - tree-sitter>=0.23.0 ; python_full_version >= '3.9' and extra == 'syntax'
+  - tree-sitter-bash>=0.23.0 ; python_full_version >= '3.9' and extra == 'syntax'
+  - tree-sitter-css>=0.23.0 ; python_full_version >= '3.9' and extra == 'syntax'
+  - tree-sitter-go>=0.23.0 ; python_full_version >= '3.9' and extra == 'syntax'
+  - tree-sitter-html>=0.23.0 ; python_full_version >= '3.9' and extra == 'syntax'
+  - tree-sitter-java>=0.23.0 ; python_full_version >= '3.9' and extra == 'syntax'
+  - tree-sitter-javascript>=0.23.0 ; python_full_version >= '3.9' and extra == 'syntax'
+  - tree-sitter-json>=0.24.0 ; python_full_version >= '3.9' and extra == 'syntax'
+  - tree-sitter-markdown>=0.3.0 ; python_full_version >= '3.9' and extra == 'syntax'
+  - tree-sitter-python>=0.23.0 ; python_full_version >= '3.9' and extra == 'syntax'
+  - tree-sitter-regex>=0.24.0 ; python_full_version >= '3.9' and extra == 'syntax'
+  - tree-sitter-rust>=0.23.0,<=0.23.2 ; python_full_version >= '3.9' and extra == 'syntax'
+  - tree-sitter-sql>=0.3.0,<0.3.8 ; python_full_version >= '3.9' and extra == 'syntax'
+  - tree-sitter-toml>=0.6.0 ; python_full_version >= '3.9' and extra == 'syntax'
+  - tree-sitter-xml>=0.7.0 ; python_full_version >= '3.9' and extra == 'syntax'
+  - tree-sitter-yaml>=0.6.0 ; python_full_version >= '3.9' and extra == 'syntax'
+  - typing-extensions>=4.4.0,<5.0.0
+  requires_python: '>=3.8.1,<4.0.0'
 - pypi: https://files.pythonhosted.org/packages/cd/4c/22eb8e9856a2b1808d0a002d171e534eac03f96dbe1161978d7389a59498/tiktoken-0.9.0-cp310-cp310-win_amd64.whl
   name: tiktoken
   version: 0.9.0
@@ -6744,6 +6835,15 @@ packages:
   purls: []
   size: 122968
   timestamp: 1742727099393
+- pypi: https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl
+  name: uc-micro-py
+  version: 1.0.3
+  sha256: db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5
+  requires_dist:
+  - pytest ; extra == 'test'
+  - coverage ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
   sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
   md5: 6797b005cd0f439c4c5c9ac565783700

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,7 @@ dev = []  # Empty; dev deps handled in pixi sections
 extras = ["crystallize-extras"]
 ray = ["ray"]
 vllm = ["vllm"]
-cli = [
-    "textual",
-    "simple-term-menu",
-]
+cli = ["textual"]
 
 [project.urls]
 Homepage = "https://github.com/brysontang/crystallize"
@@ -90,6 +87,7 @@ lazydocs = ">=0.4.8,<0.5"
 build = ">=1.2.2.post1,<2"
 twine = ">=5.1.0,<6"
 diff-cover = "*"
+textual = "*"
 
 [tool.pixi.feature.extras.pypi-dependencies]
 crystallize-ml = "*"


### PR DESCRIPTION
### Summary
- use Textual widgets instead of TerminalMenu for interactive CLI
- update optional CLI dependencies
- add textual to dev environment

### Changes
- implement `DeleteDataScreen`, `StrategyScreen`, `ConfirmScreen`, `SummaryScreen`
- rework `_run_interactive` to use Textual screens
- update pyproject and lock file for new dependency

### Testing & Verification
- `pixi run format`
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_68817b6830188329828a4b871a5131af