### PR TITLE
Add CLI execution progress plugin

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,4 +1,5 @@
 """CLI package for crystallize."""
 from .app import run
+from .status_plugin import CLIStatusPlugin
 
-__all__ = ["run"]
+__all__ = ["run", "CLIStatusPlugin"]

--- a/cli/screens/delete_data.py
+++ b/cli/screens/delete_data.py
@@ -1,4 +1,5 @@
 """Screens for confirming deletion of artifacts."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -14,7 +15,10 @@ from .selection_screens import ActionableSelectionList
 
 
 class DeleteDataScreen(ModalScreen[tuple[int, ...] | None]):
-    BINDINGS = [("ctrl+c", "cancel_and_exit", "Cancel")]
+    BINDINGS = [
+        ("ctrl+c", "cancel_and_exit", "Cancel"),
+        ("q", "cancel_and_exit", "Close"),
+    ]
 
     def __init__(self, deletable: List[Tuple[str, Path]]) -> None:
         super().__init__()
@@ -53,7 +57,9 @@ class ConfirmScreen(ModalScreen[bool]):
 
     def compose(self) -> ComposeResult:
         with Container(classes="confirm-delete-container"):
-            yield Static("[bold red]The following will be permanently deleted:[/bold red]")
+            yield Static(
+                "[bold red]The following will be permanently deleted:[/bold red]"
+            )
             with VerticalScroll(classes="path-list"):
                 if not self._paths:
                     yield Static("  (Nothing selected)")

--- a/cli/screens/run.py
+++ b/cli/screens/run.py
@@ -1,4 +1,5 @@
 """Screen for running experiments and graphs."""
+
 from __future__ import annotations
 
 import asyncio
@@ -23,7 +24,9 @@ from crystallize.plugins.plugins import ArtifactPlugin
 from ..status_plugin import CLIStatusPlugin
 
 
-def _inject_status_plugin(obj: Any, callback: Callable[[str, dict[str, Any]], None]) -> None:
+def _inject_status_plugin(
+    obj: Any, callback: Callable[[str, dict[str, Any]], None]
+) -> None:
     """Inject CLIStatusPlugin into experiments if not already present."""
     if isinstance(obj, ExperimentGraph):
         for node in obj._graph.nodes:
@@ -33,6 +36,7 @@ def _inject_status_plugin(obj: Any, callback: Callable[[str, dict[str, Any]], No
     else:
         if obj.get_plugin(CLIStatusPlugin) is None:
             obj.plugins.append(CLIStatusPlugin(callback))
+
 
 from ..discovery import _run_object
 from ..widgets.writer import WidgetWriter
@@ -55,7 +59,10 @@ class RunScreen(ModalScreen[None]):
             self.result = result
             super().__init__()
 
-    BINDINGS = [("ctrl+c", "cancel_and_exit", "Cancel and Go Back")]
+    BINDINGS = [
+        ("ctrl+c", "cancel_and_exit", "Cancel and Go Back"),
+        ("q", "cancel_and_exit", "Close"),
+    ]
 
     node_states: dict[str, str] = reactive({})
     replicate_info: str = reactive("")
@@ -181,6 +188,7 @@ class RunScreen(ModalScreen[None]):
             sys.stdout = WidgetWriter(log, self.app)
             result = None
             try:
+
                 async def run_with_callback():
                     if isinstance(self._obj, ExperimentGraph):
                         return await self._obj.arun(
@@ -194,6 +202,7 @@ class RunScreen(ModalScreen[None]):
                         )
 
                 result = asyncio.run(run_with_callback())
+
             except Exception as e:  # pragma: no cover - runtime path
                 print(f"[bold red]An error occurred in the worker:\n{e}[/bold red]")
             finally:
@@ -221,6 +230,7 @@ class RunScreen(ModalScreen[None]):
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "close_run":
             self.app.pop_screen()
+
 
 async def _launch_run(app: App, obj: Any) -> None:
     selected = obj

--- a/cli/screens/run.py
+++ b/cli/screens/run.py
@@ -5,7 +5,7 @@ import asyncio
 import shutil
 import sys
 from pathlib import Path
-from typing import Any, List, Tuple
+from typing import Any, Callable, List, Tuple
 
 import networkx as nx
 from rich.text import Text
@@ -20,6 +20,19 @@ from textual.screen import ModalScreen
 from crystallize.experiments.experiment import Experiment
 from crystallize.experiments.experiment_graph import ExperimentGraph
 from crystallize.plugins.plugins import ArtifactPlugin
+from ..status_plugin import CLIStatusPlugin
+
+
+def _inject_status_plugin(obj: Any, callback: Callable[[str, dict[str, Any]], None]) -> None:
+    """Inject CLIStatusPlugin into experiments if not already present."""
+    if isinstance(obj, ExperimentGraph):
+        for node in obj._graph.nodes:
+            exp: Experiment = obj._graph.nodes[node]["experiment"]
+            if exp.get_plugin(CLIStatusPlugin) is None:
+                exp.plugins.append(CLIStatusPlugin(callback))
+    else:
+        if obj.get_plugin(CLIStatusPlugin) is None:
+            obj.plugins.append(CLIStatusPlugin(callback))
 
 from ..discovery import _run_object
 from ..widgets.writer import WidgetWriter
@@ -45,6 +58,9 @@ class RunScreen(ModalScreen[None]):
     BINDINGS = [("ctrl+c", "cancel_and_exit", "Cancel and Go Back")]
 
     node_states: dict[str, str] = reactive({})
+    replicate_info: str = reactive("")
+    progress_percent: float = reactive(0.0)
+    step_states: dict[str, str] = reactive({})
 
     def __init__(self, obj: Any, strategy: str, replicates: int | None) -> None:
         super().__init__()
@@ -77,10 +93,65 @@ class RunScreen(ModalScreen[None]):
     def on_node_status_changed(self, message: NodeStatusChanged) -> None:
         self.node_states = {**self.node_states, message.node_name: message.status}
 
+    def watch_step_states(self) -> None:
+        if not self.step_states:
+            return
+        try:
+            step_widget = self.query_one("#step-display", Static)
+        except NoMatches:
+            return
+        text = Text(justify="center")
+        steps = list(self.step_states.keys())
+        for i, step in enumerate(steps):
+            status = self.step_states[step]
+            style = {
+                "completed": "bold green",
+                "pending": "bold white",
+            }.get(status, "bold white")
+            text.append(f"[ {step} ]", style=style)
+            if i < len(steps) - 1:
+                text.append(" ⟶  ", style="white")
+        step_widget.update(text)
+
+    def watch_replicate_info(self) -> None:
+        try:
+            rep_widget = self.query_one("#replicate-display", Static)
+        except NoMatches:
+            return
+        rep_widget.update(self.replicate_info)
+
+    def watch_progress_percent(self) -> None:
+        try:
+            prog_widget = self.query_one("#progress-display", Static)
+        except NoMatches:
+            return
+        filled = int(self.progress_percent * 20)
+        bar = "[" + "#" * filled + "-" * (20 - filled) + "]"
+        prog_widget.update(f"{bar} {self.progress_percent*100:.0f}%")
+
+    def _handle_status_event(self, event: str, info: dict[str, Any]) -> None:
+        if event == "start":
+            self.step_states = {name: "pending" for name in info.get("steps", [])}
+            self.progress_percent = 0.0
+            self.replicate_info = "Run started"
+        elif event == "replicate":
+            rep = info.get("replicate", 0)
+            total = info.get("total", 0)
+            cond = info.get("condition", "")
+            self.replicate_info = f"Replicate {rep}/{total} ({cond})"
+        elif event == "step":
+            step = info.get("step")
+            if step and step in self.step_states:
+                self.step_states[step] = "completed"
+            self.progress_percent = info.get("percent", 0.0)
+
     def compose(self) -> ComposeResult:
         with VerticalScroll(id="run-container"):
             yield Header(show_clock=True)
             yield Static(f"⚡ Running: {self._obj.name}", id="modal-title")
+            yield Static("Run started", id="replicate-display")
+            yield Static(id="step-display")
+            yield Static(id="progress-display")
             yield Static(id="dag-display", classes="hidden")
             yield RichLog(highlight=True, markup=True, id="live_log")
             yield Button("Close", id="close_run")
@@ -93,6 +164,11 @@ class RunScreen(ModalScreen[None]):
             self.node_states = {node: "pending" for node in self._obj._graph.nodes}
             self.query_one("#dag-display").remove_class("hidden")
         log = self.query_one("#live_log", RichLog)
+
+        def status_event(event: str, info: dict[str, Any]) -> None:
+            self.app.call_from_thread(self._handle_status_event, event, info)
+
+        _inject_status_plugin(self._obj, status_event)
 
         async def progress_callback(status: str, name: str) -> None:
             self.app.call_from_thread(

--- a/cli/screens/run.py
+++ b/cli/screens/run.py
@@ -139,6 +139,7 @@ class RunScreen(ModalScreen[None]):
             total = info.get("total", 0)
             cond = info.get("condition", "")
             self.replicate_info = f"Replicate {rep}/{total} ({cond})"
+            self.step_states = {name: "pending" for name in self.step_states}
         elif event == "step":
             step = info.get("step")
             if step and step in self.step_states:

--- a/cli/screens/selection_screens.py
+++ b/cli/screens/selection_screens.py
@@ -1,4 +1,5 @@
 """Reusable selection widgets for the CLI."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -18,5 +19,7 @@ class ActionableSelectionList(SelectionList):
     BINDINGS = [("enter", "submit", "Submit")]
 
     def action_submit(self) -> None:
-        selected_indices = tuple(value for value in self.selected if isinstance(value, int))
+        selected_indices = tuple(
+            value for value in self.selected if isinstance(value, int)
+        )
         self.post_message(self.Submitted(selected_indices))

--- a/cli/screens/strategy.py
+++ b/cli/screens/strategy.py
@@ -1,4 +1,5 @@
 """Screen for selecting execution strategy."""
+
 from __future__ import annotations
 
 from textual.app import ComposeResult
@@ -9,7 +10,10 @@ from textual.screen import ModalScreen
 
 
 class StrategyScreen(ModalScreen[str | None]):
-    BINDINGS = [("ctrl+c", "cancel_and_exit", "Cancel")]
+    BINDINGS = [
+        ("ctrl+c", "cancel_and_exit", "Cancel"),
+        ("q", "cancel_and_exit", "Close"),
+    ]
 
     def compose(self) -> ComposeResult:
         with Container():

--- a/cli/screens/summary.py
+++ b/cli/screens/summary.py
@@ -1,4 +1,5 @@
 """Screen for displaying run summaries."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -14,7 +15,7 @@ from ..utils import _write_summary
 class SummaryScreen(ModalScreen[None]):
     """Display the summary of an experiment run."""
 
-    BINDINGS = [("ctrl+c", "close", "Close")]
+    BINDINGS = [("ctrl+c", "close", "Close"), ("q", "close", "Close")]
 
     def __init__(self, result: Any) -> None:
         super().__init__()

--- a/cli/status_plugin.py
+++ b/cli/status_plugin.py
@@ -32,7 +32,9 @@ class CLIStatusPlugin(BasePlugin):
             {
                 "steps": self.steps,
                 "replicates": self.total_replicates,
-                "total": self.total_steps * self.total_replicates * self.total_conditions,
+                "total": self.total_steps
+                * self.total_replicates
+                * self.total_conditions,
             },
         )
 

--- a/cli/status_plugin.py
+++ b/cli/status_plugin.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, List
+
+from crystallize.plugins.plugins import BasePlugin
+from crystallize.utils.constants import BASELINE_CONDITION, CONDITION_KEY, REPLICATE_KEY
+from crystallize.utils.context import FrozenContext
+from crystallize.pipelines.pipeline_step import PipelineStep
+from crystallize.experiments.experiment import Experiment
+
+
+@dataclass
+class CLIStatusPlugin(BasePlugin):
+    """Track progress of an experiment for the CLI."""
+
+    callback: Callable[[str, dict[str, Any]], None]
+    total_steps: int = field(init=False, default=0)
+    total_replicates: int = field(init=False, default=0)
+    total_conditions: int = field(init=False, default=0)
+    completed: int = field(init=False, default=0)
+    steps: List[str] = field(init=False, default_factory=list)
+
+    def before_run(self, experiment: Experiment) -> None:
+        self.steps = [step.__class__.__name__ for step in experiment.pipeline.steps]
+        self.total_steps = len(self.steps)
+        self.total_replicates = experiment.replicates
+        self.total_conditions = len(experiment.treatments) + 1
+        self.completed = 0
+        self.callback(
+            "start",
+            {
+                "steps": self.steps,
+                "replicates": self.total_replicates,
+                "total": self.total_steps * self.total_replicates * self.total_conditions,
+            },
+        )
+
+    def before_replicate(self, experiment: Experiment, ctx: FrozenContext) -> None:
+        rep = ctx.get(REPLICATE_KEY, 0) + 1
+        condition = ctx.get(CONDITION_KEY, BASELINE_CONDITION)
+        if condition == BASELINE_CONDITION:
+            self.current_replicate = rep
+        self.current_condition = condition
+        self.callback(
+            "replicate",
+            {
+                "replicate": getattr(self, "current_replicate", rep),
+                "total": self.total_replicates,
+                "condition": condition,
+            },
+        )
+
+    def after_step(
+        self,
+        experiment: Experiment,
+        step: PipelineStep,
+        data: Any,
+        ctx: FrozenContext,
+    ) -> None:
+        self.completed += 1
+        percent = 0.0
+        total = self.total_steps * self.total_replicates * self.total_conditions
+        if total:
+            percent = self.completed / total
+        self.callback(
+            "step",
+            {
+                "step": step.__class__.__name__,
+                "percent": percent,
+            },
+        )

--- a/crystallize/experiments/experiment.py
+++ b/crystallize/experiments/experiment.py
@@ -399,6 +399,7 @@ class Experiment:
         errors: Dict[str, Exception] = {}
 
         for rep, res in enumerate(results_list):
+
             base = res.baseline_metrics
             seed = res.baseline_seed
             treats = res.treatment_metrics
@@ -422,15 +423,17 @@ class Experiment:
             samples: List[Mapping[str, Sequence[Any]]],
         ) -> Dict[str, List[Any]]:
             metrics: DefaultDict[str, List[Any]] = defaultdict(list)
-            for sample in samples:
+            for i, sample in enumerate(samples):
                 for metric, values in sample.items():
                     metrics[metric].extend(list(values))
-            return dict(metrics)
+            result = dict(metrics)
+            return result
 
         baseline_metrics = collect_all_samples(baseline_samples)
-        treatment_metrics_dict = {
-            name: collect_all_samples(samp) for name, samp in treatment_samples.items()
-        }
+
+        treatment_metrics_dict = {}
+        for name, samp in treatment_samples.items():
+            treatment_metrics_dict[name] = collect_all_samples(samp)
 
         return AggregateData(
             baseline_metrics=baseline_metrics,
@@ -593,6 +596,7 @@ class Experiment:
                                     run_baseline=run_baseline,
                                 )
                             )
+
                     else:
 
                         async def replicate_fn(rep: int) -> ReplicateResult:

--- a/crystallize/experiments/experiment_graph.py
+++ b/crystallize/experiments/experiment_graph.py
@@ -241,9 +241,9 @@ class ExperimentGraph:
                 replicates=replicates or getattr(exp, "replicates", 1),
                 strategy=run_strategy,
             )
+
             self._results[name] = result
 
             if progress_callback:
                 await progress_callback("completed", name)
-
         return self._results

--- a/docs/src/content/docs/how-to/creating-plugins.md
+++ b/docs/src/content/docs/how-to/creating-plugins.md
@@ -42,4 +42,4 @@ exp.run()
 
 ## CLIStatusPlugin
 
-The interactive CLI injects a small `CLIStatusPlugin` into your experiments when running them. This plugin reports the current replicate, step and overall progress back to the UI so the header can display live status information. The CLI first checks whether your experiment already includes this plugin before adding it. You normally don't need to use it directly, but it demonstrates how plugins can communicate runtime events back to external tools.
+The interactive CLI injects a small `CLIStatusPlugin` into your experiments when running them. This plugin reports the current replicate, step and overall progress back to the UI so the header can display live status information. The CLI first checks whether your experiment already includes this plugin before adding it. Step status is reset for every treatment so the UI can highlight each step once it completes. You normally don't need to use this plugin directly, but it demonstrates how plugins can communicate runtime events back to external tools.

--- a/docs/src/content/docs/how-to/creating-plugins.md
+++ b/docs/src/content/docs/how-to/creating-plugins.md
@@ -39,3 +39,7 @@ exp = Experiment(
 exp.validate()
 exp.run()
 ```
+
+## CLIStatusPlugin
+
+The interactive CLI injects a small `CLIStatusPlugin` into your experiments when running them. This plugin reports the current replicate, step and overall progress back to the UI so the header can display live status information. The CLI first checks whether your experiment already includes this plugin before adding it. You normally don't need to use it directly, but it demonstrates how plugins can communicate runtime events back to external tools.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ extras = ["crystallize-extras"]
 ray = ["ray"]
 vllm = ["vllm"]
 cli = ["textual"]
+all = ["crystallize-extras", "ray", "vllm", "textual"]
 
 [project.urls]
 Homepage = "https://github.com/brysontang/crystallize"

--- a/tests/test_cli_status_plugin.py
+++ b/tests/test_cli_status_plugin.py
@@ -1,0 +1,67 @@
+from crystallize import data_source, pipeline_step
+from crystallize.experiments.experiment import Experiment
+from crystallize.experiments.experiment_graph import ExperimentGraph
+from crystallize.pipelines.pipeline import Pipeline
+from crystallize.experiments.treatment import Treatment
+from cli.status_plugin import CLIStatusPlugin
+from cli.screens.run import _inject_status_plugin
+
+
+events = []
+
+def record(event: str, info: dict[str, object]) -> None:
+    events.append((event, info))
+
+
+@data_source
+def ds(ctx):
+    return 0
+
+
+@pipeline_step()
+def step_a(data, ctx):
+    return data
+
+
+@pipeline_step()
+def step_b(data, ctx):
+    return data
+
+
+def test_cli_status_plugin_progress():
+    plugin = CLIStatusPlugin(record)
+    treatment = Treatment("t", {})
+    exp = Experiment(
+        datasource=ds(),
+        pipeline=Pipeline([step_a(), step_b()]),
+        plugins=[plugin],
+        treatments=[treatment],
+        replicates=2,
+    )
+    exp.validate()
+    exp.run(treatments=[treatment], replicates=2)
+
+    assert events[0][0] == "start"
+    assert any(evt == "replicate" for evt, _ in events)
+    step_events = [info for evt, info in events if evt == "step"]
+    assert step_events[-1]["percent"] == 1.0
+
+
+def test_inject_status_plugin_deduplicates_experiment():
+    plugin = CLIStatusPlugin(lambda e, i: None)
+    exp = Experiment(datasource=ds(), pipeline=Pipeline([step_a()]), plugins=[plugin])
+    exp.validate()
+    _inject_status_plugin(exp, lambda e, i: None)
+    count = sum(isinstance(p, CLIStatusPlugin) for p in exp.plugins)
+    assert count == 1
+
+
+def test_inject_status_plugin_deduplicates_graph():
+    plugin = CLIStatusPlugin(lambda e, i: None)
+    exp = Experiment(datasource=ds(), pipeline=Pipeline([step_a()]), plugins=[plugin], name="e")
+    exp.validate()
+    graph = ExperimentGraph.from_experiments([exp])
+    _inject_status_plugin(graph, lambda e, i: None)
+    exp2 = graph._graph.nodes["e"]["experiment"]
+    count = sum(isinstance(p, CLIStatusPlugin) for p in exp2.plugins)
+    assert count == 1

--- a/tests/test_cli_status_plugin.py
+++ b/tests/test_cli_status_plugin.py
@@ -9,6 +9,7 @@ from cli.screens.run import _inject_status_plugin
 
 events = []
 
+
 def record(event: str, info: dict[str, object]) -> None:
     events.append((event, info))
 
@@ -45,6 +46,8 @@ def test_cli_status_plugin_progress():
     assert any(evt == "replicate" for evt, _ in events)
     step_events = [info for evt, info in events if evt == "step"]
     assert step_events[-1]["percent"] == 1.0
+    rep_events = [info for evt, info in events if evt == "replicate"]
+    assert len(rep_events) == 4
 
 
 def test_inject_status_plugin_deduplicates_experiment():
@@ -58,7 +61,9 @@ def test_inject_status_plugin_deduplicates_experiment():
 
 def test_inject_status_plugin_deduplicates_graph():
     plugin = CLIStatusPlugin(lambda e, i: None)
-    exp = Experiment(datasource=ds(), pipeline=Pipeline([step_a()]), plugins=[plugin], name="e")
+    exp = Experiment(
+        datasource=ds(), pipeline=Pipeline([step_a()]), plugins=[plugin], name="e"
+    )
     exp.validate()
     graph = ExperimentGraph.from_experiments([exp])
     _inject_status_plugin(graph, lambda e, i: None)


### PR DESCRIPTION
### Summary
Adds a helper to avoid injecting duplicate CLIStatusPlugins and updates tests and docs.

### Changes
- `RunScreen` now uses `_inject_status_plugin` to check for an existing plugin
- documentation clarifies that duplicates are avoided
- new tests ensure plugin injection is idempotent

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_6881f9ef4dec832984bdd042f73f9697