### PR TITLE
Fix hypothesis pickling and async execution

### DIFF
--- a/crystallize/pipelines/pipeline.py
+++ b/crystallize/pipelines/pipeline.py
@@ -68,12 +68,7 @@ class Pipeline:
 
             pre_ctx = dict(ctx.as_dict())
             pre_metrics = {k: tuple(v) for k, v in ctx.metrics.as_dict().items()}
-            try:
-                step_hash = step.step_hash
-            except Exception as exc:
-                print(f"Error in step {step.__class__.__name__}")
-                print(f"Error: {exc}")
-                raise exc
+            step_hash = step.step_hash
             input_hash = compute_hash(data)
             if step.cacheable:
                 try:

--- a/crystallize/utils/decorators.py
+++ b/crystallize/utils/decorators.py
@@ -164,12 +164,9 @@ def hypothesis(
     """Decorate a ranker function and produce a :class:`Hypothesis`."""
 
     def decorator(fn: Callable[[Mapping[str, Any]], float]) -> Hypothesis:
-        def factory() -> Hypothesis:
-            return Hypothesis(
-                verifier=verifier, metrics=metrics, ranker=fn, name=name or fn.__name__
-            )
-
-        return update_wrapper(factory, fn)
+        return Hypothesis(
+            verifier=verifier, metrics=metrics, ranker=fn, name=name or fn.__name__
+        )
 
     return decorator
 


### PR DESCRIPTION
### Summary
- revert hypothesis decorator to return a Hypothesis instance
- make verifier callable picklable while keeping behaviour
- clean up pipeline step hashing debug output
- test that async execution works with hypotheses and verifiers

### Changes
- adjust `hypothesis` decorator logic
- remove debug try/except from pipeline
- add async execution test for hypothesis/verifier

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_6882b6364b908329ba95083c9c04d49b