### PR TITLE
feat(crystallize-ml): infer experiment graph deps automatically

### DIFF
--- a/crystallize/experiments/experiment_graph.py
+++ b/crystallize/experiments/experiment_graph.py
@@ -22,10 +22,17 @@ from .treatment import Treatment
 class ExperimentGraph:
     """Manage and run a directed acyclic graph of experiments."""
 
-    def __init__(self, name: str | None = None) -> None:
+    def __init__(self, *experiments: Experiment, name: str | None = None) -> None:
+        """Create a graph and optionally infer dependencies from experiments."""
         self._graph = nx.DiGraph()
         self._results: Dict[str, Result] = {}
         self._name = name
+
+        if experiments:
+            tmp = self.__class__.from_experiments(list(experiments))
+            self._graph = tmp._graph
+            if name is None:
+                self._name = tmp._name
 
     # ------------------------------------------------------------------ #
     @classmethod

--- a/docs/src/content/docs/how-to/dag-experiments.md
+++ b/docs/src/content/docs/how-to/dag-experiments.md
@@ -7,12 +7,13 @@ Crystallize can orchestrate complex workflows by chaining experiments in a direc
 
 ## 1. Build a Graph
 
-Use `ExperimentGraph.from_experiments()` to automatically discover dependencies:
+Create an ``ExperimentGraph`` with your experiments and it will infer
+dependencies automatically:
 
 ```python
 from crystallize import ExperimentGraph
 
-graph = ExperimentGraph.from_experiments([exp_a, exp_b])
+graph = ExperimentGraph(exp_a, exp_b)
 ```
 
 Running `graph.run()` executes experiments in topological order.

--- a/docs/src/content/docs/reference/experiment_graph.md
+++ b/docs/src/content/docs/reference/experiment_graph.md
@@ -16,8 +16,11 @@ Manage and run a directed acyclic graph of experiments.
 ### <kbd>method</kbd> `ExperimentGraph.__init__`
 
 ```python
-__init__() → None
+__init__(*experiments: Experiment, name: str | None = None) → None
 ```
+
+Initialize a graph. If ``experiments`` are provided, dependencies are
+inferred automatically using :func:`~ExperimentGraph.from_experiments`.
 
 
 

--- a/examples/dag_experiment/main.py
+++ b/examples/dag_experiment/main.py
@@ -84,7 +84,7 @@ comfort_exp.validate()
 
 
 if __name__ == "__main__":
-    graph = ExperimentGraph.from_experiments([temp_exp, humidity_exp, comfort_exp])
+    graph = ExperimentGraph(temp_exp, humidity_exp, comfort_exp)
 
     print("Baseline run:")
     base = graph.run()


### PR DESCRIPTION
### Summary
- let `ExperimentGraph` optionally build itself from passed experiments
- update DAG example to show new API
- document automatic dependency inference
- add test ensuring constructor infers dependencies

### Changes
- extend `ExperimentGraph.__init__` to accept experiments and call `from_experiments`
- update docs and example script
- add `test_constructor_infers_dependencies`

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_6882dba49128832981daa49dd05bb635