### PR TITLE
Add folder-based YAML loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ print(result.hypothesis_result)
 result.print_tree()
 ```
 
+For a minimal YAML-driven setup, see [`examples/folder_experiment`](examples/folder_experiment).
+
 ### Command Line Interface
 
 Crystallize ships with an interactive CLI for discovering and executing

--- a/crystallize/yaml_cli/main.py
+++ b/crystallize/yaml_cli/main.py
@@ -4,7 +4,7 @@ import argparse
 from pathlib import Path
 from typing import List
 
-from .yaml_loader import load_experiment_from_file
+from crystallize.experiments.experiment import Experiment
 from rich.console import Console
 from rich.table import Table
 
@@ -19,7 +19,7 @@ def main(argv: List[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     if args.command == "run":
-        experiment = load_experiment_from_file(args.config)
+        experiment = Experiment.from_yaml(args.config)
         experiment.validate()
         result = experiment.run(
             treatments=experiment.treatments,

--- a/docs/src/content/docs/tutorials/adding-treatments.md
+++ b/docs/src/content/docs/tutorials/adding-treatments.md
@@ -192,4 +192,4 @@ To add ML: In pipeline, fit `from sklearn.linear_model import LinearRegression` 
 - **Custom Variations**: How-to Guides: How to add a custom treatment.
 - **Reference**: Treatment, Experiment (for baselines).
 - **Explanations**: Why baselines? See Explanation: Controlled experiments.
-- Experiment with multiple treatments or real Titanic CSV. Link to `examples/yaml_experiment` for config-based runs.
+- Experiment with multiple treatments or real Titanic CSV. Link to `examples/folder_experiment` for config-based runs.

--- a/examples/folder_experiment/config.yaml
+++ b/examples/folder_experiment/config.yaml
@@ -1,0 +1,9 @@
+name: folder_exp
+datasource:
+  num: numbers
+steps:
+  - add_one
+hypotheses:
+  - name: check
+    verifier: always_sig
+    metrics: val

--- a/examples/folder_experiment/datasources.py
+++ b/examples/folder_experiment/datasources.py
@@ -1,0 +1,6 @@
+from crystallize import data_source
+
+
+@data_source
+def numbers(ctx):
+    return 1

--- a/examples/folder_experiment/hypotheses.py
+++ b/examples/folder_experiment/hypotheses.py
@@ -1,0 +1,6 @@
+from crystallize import verifier
+
+
+@verifier
+def always_sig(baseline, treatment):
+    return {"p_value": 0.01, "significant": True}

--- a/examples/folder_experiment/main.py
+++ b/examples/folder_experiment/main.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+from crystallize.experiments.experiment import Experiment
+
+if __name__ == "__main__":
+    exp = Experiment.from_yaml(Path(__file__).parent / "config.yaml")
+    exp.validate()
+    res = exp.run()
+    print(res.metrics.baseline.metrics)

--- a/examples/folder_experiment/steps.py
+++ b/examples/folder_experiment/steps.py
@@ -1,0 +1,8 @@
+from crystallize import pipeline_step
+from crystallize.utils.context import FrozenContext
+
+
+@pipeline_step()
+def add_one(data: int, ctx: FrozenContext) -> dict:
+    ctx.metrics.add("val", data + 1)
+    return {"val": data + 1}

--- a/tests/test_from_yaml.py
+++ b/tests/test_from_yaml.py
@@ -1,0 +1,98 @@
+import yaml
+from pathlib import Path
+
+from crystallize.experiments.experiment import Experiment
+from crystallize.experiments.experiment_graph import ExperimentGraph
+
+from crystallize import data_source, pipeline_step, verifier
+
+
+@data_source
+def constant(ctx, value=1):
+    return value
+
+
+@pipeline_step()
+def add_one(data, ctx):
+    ctx.metrics.add("val", data + 1)
+    ctx.artifacts.add("artifact.txt", b"data")
+    return {"val": data + 1}
+
+
+@verifier
+def always_sig(baseline, treatment):
+    return {"p_value": 0.01, "significant": True}
+
+
+def create_exp(tmp, name="exp"):
+    d = tmp / name
+    d.mkdir()
+    (d / "datasources.py").write_text("from test_from_yaml import constant\n")
+    (d / "steps.py").write_text("from test_from_yaml import add_one\n")
+    (d / "hypotheses.py").write_text("from test_from_yaml import always_sig\n")
+    cfg = {
+        "name": name,
+        "datasource": {"x": "constant"},
+        "steps": ["add_one"],
+        "hypotheses": [{"name": "h", "verifier": "always_sig", "metrics": "val"}],
+        "treatments": [{"name": "control"}],
+        "outputs": {"artifact": {}},
+    }
+    (d / "config.yaml").write_text(yaml.safe_dump(cfg))
+    return d
+
+
+def test_experiment_from_yaml(tmp_path: Path):
+    exp_dir = create_exp(tmp_path)
+    exp = Experiment.from_yaml(exp_dir / "config.yaml")
+    exp.validate()
+    res = exp.run()
+    assert res.metrics.baseline.metrics["val"] == [2]
+
+
+def test_graph_from_yaml(tmp_path: Path):
+    exp_dir = create_exp(tmp_path)
+    graph = ExperimentGraph.from_yaml(tmp_path)
+    res = graph.run()
+    assert res[exp_dir.name].metrics.baseline.metrics["val"] == [2]
+
+
+def test_from_yaml_relative(monkeypatch, tmp_path: Path):
+    exp_dir = create_exp(tmp_path, name="rel")
+    monkeypatch.chdir(tmp_path)
+    exp = Experiment.from_yaml(exp_dir / "config.yaml")
+    exp.validate()
+    res = exp.run()
+    assert res.metrics.baseline.metrics["val"] == [2]
+
+
+def test_from_yaml_with_artifact(tmp_path: Path):
+    prod_dir = create_exp(tmp_path, name="producer")
+    prod = Experiment.from_yaml(prod_dir / "config.yaml")
+    prod.validate()
+    prod.run()
+
+    cons = tmp_path / "consumer"
+    cons.mkdir()
+    (cons / "datasources.py").write_text(
+        "from crystallize import data_source\n"
+        "@data_source\n"
+        "def dummy(ctx):\n    return 0\n"
+    )
+    (cons / "steps.py").write_text(
+        "from crystallize import pipeline_step\n"
+        "@pipeline_step()\n"
+        "def passthrough(data, ctx):\n    ctx.metrics.add('val', 0)\n    return {'val': 0}\n"
+    )
+    cfg = {
+        "name": "consumer",
+        "datasource": {"prev": "producer#artifact"},
+        "steps": ["passthrough"],
+        "treatments": [],
+        "hypotheses": [],
+    }
+    (cons / "config.yaml").write_text(yaml.safe_dump(cfg))
+
+    graph = ExperimentGraph.from_yaml(tmp_path)
+    res = graph.run()
+    assert "consumer" in res


### PR DESCRIPTION
### Summary
Implemented support for loading experiments from folder-based YAML configs.

### Changes
- added `Experiment.from_yaml` and `ExperimentGraph.from_yaml` parsing helpers
- updated CLI to use new loader
- added example `examples/folder_experiment`
- expanded tests with new fixtures for folder-based YAML
- updated docs and README references

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`

------
https://chatgpt.com/codex/tasks/task_e_688479031d3c832987eebcf05da69654