### PR TITLE
feat: improve YAML artifact mapping

### DIFF
--- a/crystallize/experiments/experiment.py
+++ b/crystallize/experiments/experiment.py
@@ -933,8 +933,14 @@ class Experiment:
             # Inspect the step factory's signature and map any Artifact parameters
             sig = inspect.signature(step_factory)
             for param_name, param in sig.parameters.items():
-                if param.annotation == Artifact and param_name in outputs_map:
-                    kwargs[param_name] = outputs_map[param_name]
+                if param.annotation == Artifact:
+                    # Allow explicit mapping of output names via kwargs
+                    if param_name in kwargs and isinstance(kwargs[param_name], str):
+                        alias = kwargs[param_name]
+                        if alias in outputs_map:
+                            kwargs[param_name] = outputs_map[alias]
+                    elif param_name in outputs_map and param_name not in kwargs:
+                        kwargs[param_name] = outputs_map[param_name]
             steps.append(step_factory(**kwargs))
         pipeline = Pipeline(steps)
 


### PR DESCRIPTION
### Summary
Allow YAML configs to map pipeline step artifact parameters to differently named outputs.

### Changes
- map artifact parameters using explicit output aliases
- add tests covering alias, default, and multi-output mappings

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_6884a5783ac48329b067e213f67d517b