### PR TITLE
feat(crystallize-ml): support tuple metrics in pipeline steps

### DIFF
--- a/docs/src/content/docs/how-to/custom-steps.md
+++ b/docs/src/content/docs/how-to/custom-steps.md
@@ -7,8 +7,8 @@ Crystallize pipelines are built from small, deterministic **steps**. This guide 
 
 ## 1. Define a Step with `@pipeline_step`
 
-Use the decorator on a regular function. `data` and `ctx` are required
-arguments. Additional keyword arguments make your step configurable and are
+Use the decorator on a regular function. `data` is required while `ctx` is
+optional. Additional keyword arguments make your step configurable and are
 automatically pulled from the execution context when not supplied explicitly.
 
 ```python
@@ -69,14 +69,13 @@ def normalize(data: list, ctx: FrozenContext) -> list:
 
 ## 4. Recording Metrics
 
-Each context has a `metrics` object used to accumulate results. Use `ctx.metrics.add(name, value)` to record values in any step. Metrics are aggregated across replicates and passed to hypotheses for verification. The last step may return any data type—returning metrics is optional.
+Each context has a `metrics` object used to accumulate results. Use `ctx.metrics.add(name, value)` to record values in any step. Metrics are aggregated across replicates and passed to hypotheses for verification. Steps may also return a tuple `(data, metrics_dict)` to add metrics without mutating the context directly.
 
 ```python
 @pipeline_step()
-def compute_sum(data, ctx: FrozenContext):
+def compute_sum(data):
     total = sum(data)
-    ctx.metrics.add("sum", total)
-    return data
+    return data, {"sum": total}
 ```
 
 Intermediate steps may also write metrics if useful. All metrics collected across replicates are provided to verifiers.

--- a/examples/minimal_experiment/main.py
+++ b/examples/minimal_experiment/main.py
@@ -40,10 +40,9 @@ def add_random(data, ctx: FrozenContext):
     return [x + random.random() for x in data]
 
 @pipeline_step()
-def compute_metrics(data, ctx: FrozenContext):
-    # Record a simple metric for later verification
-    ctx.metrics.add("result", sum(data))
-    return data
+def compute_metrics(data):
+    """Return the data and a metrics dictionary."""
+    return data, {"result": sum(data)}
 
 # 3. Define the treatment (the change we are testing)
 add_ten = treatment(

--- a/tests/test_pipeline_step.py
+++ b/tests/test_pipeline_step.py
@@ -49,3 +49,14 @@ def test_pipeline_step_factory_defaults_and_hash():
 def test_pipeline_step_factory_missing_param():
     with pytest.raises(TypeError):
         multiply()
+
+
+@pipeline_step()
+def no_ctx_step(data, *, inc: int = 1):
+    return data + inc
+
+
+def test_pipeline_step_without_ctx_parameter():
+    ctx = FrozenContext({"inc": 2})
+    step = no_ctx_step()
+    assert step(3, ctx) == 5


### PR DESCRIPTION
### Summary
- allow pipeline steps to omit `ctx` and return `(data, metrics)`
- handle tuple-based metrics in pipeline run
- document optional `ctx` and tuple returns
- update minimal example
- add tests for new behaviour

### Changes
- updated `inject_from_ctx` to inject context even if step lacks `ctx`
- enhanced `Pipeline` to unpack `(data, metrics)`
- docs and example updates
- new pipeline tests for tuple metrics and tuple data
- new step test for functions without `ctx`

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_6884a77913ec8329884757acc418fea6