### PR TITLE
feat: display CLI load errors

### DIFF
--- a/cli/app.py
+++ b/cli/app.py
@@ -40,7 +40,12 @@ class CrystallizeApp(App):
         ("r", "refresh", "Refresh"),
         ("c", "create_experiment", "Create Experiment"),
         ("ctrl+c", "quit", "Quit"),
+        ("e", "show_errors", "Errors"),
     ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._load_errors: Dict[str, BaseException] = {}
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -59,15 +64,16 @@ class CrystallizeApp(App):
     def action_create_experiment(self) -> None:
         self.push_screen(CreateExperimentScreen())
 
-    def _discover_sync(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    def _discover_sync(self) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, BaseException]]:
         path = Path(".")
-        graphs = discover_objects(path, OBJ_TYPES["graph"])
-        experiments = discover_objects(path, OBJ_TYPES["experiment"])
-        return graphs, experiments
+        graphs, graph_errors = discover_objects(path, OBJ_TYPES["graph"])
+        experiments, exp_errors = discover_objects(path, OBJ_TYPES["experiment"])
+        return graphs, experiments, {**graph_errors, **exp_errors}
 
     async def _discover(self) -> None:
         worker = self.run_worker(self._discover_sync, thread=True)
-        graphs, experiments = await worker.wait()
+        graphs, experiments, errors = await worker.wait()
+        self._load_errors = errors
 
         main_container = self.query_one("#main-container")
         await main_container.remove_children()
@@ -87,6 +93,14 @@ class CrystallizeApp(App):
             item.data = {"obj": obj, "type": "Experiment"}
             await list_view.append(item)
 
+        if self._load_errors:
+            await main_container.mount(
+                Static(
+                    f"Failed to load {len(self._load_errors)} file(s), press e for more details",
+                    id="error-msg",
+                )
+            )
+
         list_view.focus()
 
     async def _run_interactive_and_exit(self, obj: Any) -> None:
@@ -103,6 +117,12 @@ class CrystallizeApp(App):
     async def on_list_view_selected(self, event: ListView.Selected) -> None:
         obj = event.item.data["obj"]
         self.run_worker(self._run_interactive_and_exit(obj))
+
+    def action_show_errors(self) -> None:
+        if self._load_errors:
+            from .screens.load_errors import LoadErrorsScreen
+
+            self.push_screen(LoadErrorsScreen(self._load_errors))
 
 
 def run() -> None:

--- a/cli/app.py
+++ b/cli/app.py
@@ -64,7 +64,9 @@ class CrystallizeApp(App):
     def action_create_experiment(self) -> None:
         self.push_screen(CreateExperimentScreen())
 
-    def _discover_sync(self) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, BaseException]]:
+    def _discover_sync(
+        self,
+    ) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, BaseException]]:
         path = Path(".")
         graphs, graph_errors = discover_objects(path, OBJ_TYPES["graph"])
         experiments, exp_errors = discover_objects(path, OBJ_TYPES["experiment"])

--- a/cli/discovery.py
+++ b/cli/discovery.py
@@ -5,13 +5,19 @@ import importlib.util
 import inspect
 import sys
 from pathlib import Path
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Optional, Tuple, Type
 
 from crystallize.experiments.experiment_graph import ExperimentGraph
 
 
-def _import_module(file_path: Path, root_path: Path) -> Optional[Any]:
-    """Import ``file_path`` as a module relative to ``root_path``."""
+def _import_module(
+    file_path: Path, root_path: Path
+) -> Tuple[Optional[Any], Optional[BaseException]]:
+    """Import ``file_path`` as a module relative to ``root_path``.
+
+    Returns a tuple of the imported module (or ``None`` if import failed) and
+    the exception raised during import, if any.
+    """
     try:
         relative_path = file_path.relative_to(root_path)
     except ValueError:
@@ -20,28 +26,37 @@ def _import_module(file_path: Path, root_path: Path) -> Optional[Any]:
             module = importlib.util.module_from_spec(spec)
             try:
                 spec.loader.exec_module(module)  # type: ignore[arg-type]
-                return module
-            except Exception:
-                return None
-        return None
+                return module, None
+            except BaseException as exc:  # noqa: BLE001
+                return None, exc
+        return None, RuntimeError("Could not create module spec")
 
     module_name = ".".join(relative_path.with_suffix("").parts)
 
     try:
         if str(root_path) not in sys.path:
             sys.path.insert(0, str(root_path))
-        return importlib.import_module(module_name)
-    except Exception:
-        return None
+        return importlib.import_module(module_name), None
+    except BaseException as exc:  # noqa: BLE001
+        return None, exc
 
 
-def discover_objects(directory: Path, obj_type: Type[Any]) -> Dict[str, Any]:
-    """Recursively discover objects of ``obj_type`` within ``directory``."""
+def discover_objects(
+    directory: Path, obj_type: Type[Any]
+) -> Tuple[Dict[str, Any], Dict[str, BaseException]]:
+    """Recursively discover objects of ``obj_type`` within ``directory``.
+
+    Returns a mapping of discovered objects and a mapping of file paths to
+    import errors for modules that failed to load.
+    """
     abs_directory = directory.resolve()
     root_path = Path.cwd()
     found: Dict[str, Any] = {}
+    errors: Dict[str, BaseException] = {}
     for file in abs_directory.rglob("*.py"):
-        mod = _import_module(file, root_path)
+        mod, err = _import_module(file, root_path)
+        if err is not None:
+            errors[str(file)] = err
         if not mod:
             continue
         for name, obj in inspect.getmembers(mod, lambda x: isinstance(x, obj_type)):
@@ -50,7 +65,7 @@ def discover_objects(directory: Path, obj_type: Type[Any]) -> Dict[str, Any]:
             except ValueError:
                 rel = file
             found[f"{rel}:{name}"] = obj
-    return found
+    return found, errors
 
 
 async def _run_object(obj: Any, strategy: str, replicates: Optional[int]) -> Any:

--- a/cli/screens/create_experiment.py
+++ b/cli/screens/create_experiment.py
@@ -14,6 +14,7 @@ class CreateExperimentScreen(ModalScreen[None]):
 
     BINDINGS = [
         ("ctrl+c", "cancel", "Cancel"),
+        ("escape", "cancel", "Cancel"),
         ("q", "cancel", "Close"),
         ("c", "create", "Create"),
     ]

--- a/cli/screens/delete_data.py
+++ b/cli/screens/delete_data.py
@@ -17,6 +17,7 @@ from .selection_screens import ActionableSelectionList
 class DeleteDataScreen(ModalScreen[tuple[int, ...] | None]):
     BINDINGS = [
         ("ctrl+c", "cancel_and_exit", "Cancel"),
+        ("escape", "cancel_and_exit", "Cancel"),
         ("q", "cancel_and_exit", "Close"),
     ]
 

--- a/cli/screens/load_errors.py
+++ b/cli/screens/load_errors.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from textual.app import ComposeResult
+from textual.containers import Container
+from textual.widgets import Button, Static, Tree
+from textual.screen import ModalScreen
+
+
+class LoadErrorsScreen(ModalScreen[None]):
+    """Display import errors found during discovery."""
+
+    BINDINGS = [("ctrl+c", "close", "Close"), ("q", "close", "Close")]
+
+    def __init__(self, errors: Dict[str, BaseException]) -> None:
+        super().__init__()
+        self._errors = errors
+
+    def compose(self) -> ComposeResult:
+        with Container():
+            yield Static("Load Errors", id="modal-title")
+            tree = Tree("Failed to load files")
+            for file, err in self._errors.items():
+                node = tree.root.add(str(file))
+                node.add(str(err))
+            yield tree
+            yield Button("Close", id="close")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(None)
+
+    def action_close(self) -> None:
+        self.dismiss(None)

--- a/cli/screens/load_errors.py
+++ b/cli/screens/load_errors.py
@@ -11,7 +11,11 @@ from textual.screen import ModalScreen
 class LoadErrorsScreen(ModalScreen[None]):
     """Display import errors found during discovery."""
 
-    BINDINGS = [("ctrl+c", "close", "Close"), ("q", "close", "Close")]
+    BINDINGS = [
+        ("ctrl+c", "close", "Close"),
+        ("escape", "close", "Close"),
+        ("q", "close", "Close"),
+    ]
 
     def __init__(self, errors: Dict[str, BaseException]) -> None:
         super().__init__()

--- a/cli/screens/run.py
+++ b/cli/screens/run.py
@@ -61,6 +61,7 @@ class RunScreen(ModalScreen[None]):
 
     BINDINGS = [
         ("ctrl+c", "cancel_and_exit", "Cancel and Go Back"),
+        ("escape", "cancel_and_exit", "Cancel and Go Back"),
         ("q", "cancel_and_exit", "Close"),
     ]
 

--- a/cli/screens/selection_screens.py
+++ b/cli/screens/selection_screens.py
@@ -16,7 +16,7 @@ class ActionableSelectionList(SelectionList):
             self.selected = selected
             super().__init__()
 
-    BINDINGS = [("enter", "submit", "Submit")]
+    BINDINGS = [("enter", "submit", "Submit"), ("escape", "cancel", "Cancel")]
 
     def action_submit(self) -> None:
         selected_indices = tuple(

--- a/cli/screens/strategy.py
+++ b/cli/screens/strategy.py
@@ -12,6 +12,7 @@ from textual.screen import ModalScreen
 class StrategyScreen(ModalScreen[str | None]):
     BINDINGS = [
         ("ctrl+c", "cancel_and_exit", "Cancel"),
+        ("escape", "cancel_and_exit", "Cancel"),
         ("q", "cancel_and_exit", "Close"),
     ]
 

--- a/cli/screens/summary.py
+++ b/cli/screens/summary.py
@@ -15,7 +15,11 @@ from ..utils import _write_summary
 class SummaryScreen(ModalScreen[None]):
     """Display the summary of an experiment run."""
 
-    BINDINGS = [("ctrl+c", "close", "Close"), ("q", "close", "Close")]
+    BINDINGS = [
+        ("ctrl+c", "close", "Close"),
+        ("escape", "close", "Close"),
+        ("q", "close", "Close"),
+    ]
 
     def __init__(self, result: Any) -> None:
         super().__init__()

--- a/tests/test_cli_core.py
+++ b/tests/test_cli_core.py
@@ -85,34 +85,36 @@ def make_hyp_result() -> Result:
 def test_import_module_relative(tmp_path: Path):
     mod = tmp_path / "mod.py"
     mod.write_text("X = 1")
-    m = _import_module(mod, tmp_path)
-    assert m is not None and getattr(m, "X") == 1
+    m, err = _import_module(mod, tmp_path)
+    assert m is not None and getattr(m, "X") == 1 and err is None
 
 
 def test_import_module_invalid(tmp_path: Path):
     bad = tmp_path / "bad.py"
     bad.write_text("def broken(")
-    assert _import_module(bad, tmp_path) is None
+    mod, err = _import_module(bad, tmp_path)
+    assert mod is None
 
 
 def test_import_module_absolute(tmp_path: Path):
     mod = tmp_path / "abs.py"
     mod.write_text("X = 2")
-    m = _import_module(mod, Path.cwd())
-    assert m is not None and getattr(m, "X") == 2
+    m, err = _import_module(mod, Path.cwd())
+    assert m is not None and getattr(m, "X") == 2 and err is None
 
 
 def test_import_module_runtime_error(tmp_path: Path):
     bad = tmp_path / "bad.py"
     bad.write_text("raise ValueError('boom')")
-    assert _import_module(bad, Path.cwd()) is None
+    mod, err = _import_module(bad, Path.cwd())
+    assert mod is None
 
 
 def test_discover_objects_skips_invalid(tmp_path: Path):
     create_module(tmp_path)
     bad = tmp_path / "bad.py"
     bad.write_text("def broken(")
-    exps = discover_objects(tmp_path, Experiment)
+    exps, errors = discover_objects(tmp_path, Experiment)
     assert len(exps) == 1
 
 
@@ -124,7 +126,7 @@ def test_discover_objects_nested(tmp_path: Path):
     mod1 = create_module(pkg)
     mod2 = create_module(sub)
 
-    objs = discover_objects(pkg, ExperimentGraph)
+    objs, _ = discover_objects(pkg, ExperimentGraph)
     keys = {Path(k.split(":")[0]) for k in objs}
     assert mod1 in keys and mod2 in keys
 

--- a/tests/test_cli_new.py
+++ b/tests/test_cli_new.py
@@ -37,8 +37,8 @@ def create_module(tmp: Path) -> Path:
 
 def test_discover_objects(tmp_path: Path):
     create_module(tmp_path)
-    exps = discover_objects(tmp_path, Experiment)
-    graphs = discover_objects(tmp_path, ExperimentGraph)
+    exps, _ = discover_objects(tmp_path, Experiment)
+    graphs, _ = discover_objects(tmp_path, ExperimentGraph)
     assert any(isinstance(o, Experiment) for o in exps.values())
     assert any(isinstance(o, ExperimentGraph) for o in graphs.values())
 


### PR DESCRIPTION
### Summary
Adds visibility into modules that fail to load when launching the interactive CLI.

### Changes
- return detailed import errors from `discover_objects`
- surface failures in `CrystallizeApp` and provide `LoadErrorsScreen`
- add `e` binding to view the list of failed files
- adjust tests for the new return values

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_68854e119b908329bcf8eeafde3ee785