### PR TITLE
Add graph input selection in experiment creator

### DIFF
--- a/cli/screens/create_experiment.py
+++ b/cli/screens/create_experiment.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 from pathlib import Path
+
 from textual.app import ComposeResult
 from textual.containers import Container
-from textual.widgets import Button, Checkbox, Input, Static
 from textual.screen import ModalScreen
+from textual.widgets import Button, Checkbox, Input, OptionList, Static
+from textual.widgets.selection_list import Selection
 
+from crystallize.experiments.experiment import Experiment
+
+from ..constants import OBJ_TYPES
+from ..discovery import discover_objects
 from ..utils import create_experiment_scaffolding
+from .selection_screens import ActionableSelectionList
 
 
 class CreateExperimentScreen(ModalScreen[None]):
@@ -27,6 +34,7 @@ class CreateExperimentScreen(ModalScreen[None]):
             yield Checkbox("outputs.py", id="outputs")
             yield Checkbox("hypotheses.py", id="hypotheses")
             yield Checkbox("add example code", id="examples")
+            yield Checkbox("experiment is a graph", id="graph")
             yield Button("Create", id="create")
             yield Button("Cancel", id="cancel")
 
@@ -36,21 +44,28 @@ class CreateExperimentScreen(ModalScreen[None]):
     def action_cancel(self) -> None:
         self.dismiss(None)
 
-    def action_create(self) -> None:
-        self._create()
+    async def action_create(self) -> None:
+        await self._create()
 
-    def on_button_pressed(self, event: Button.Pressed) -> None:
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "create":
-            self._create()
+            await self._create()
         else:
             self.dismiss(None)
 
-    def _create(self) -> None:
+    async def _create(self) -> None:
         name = self.query_one("#name", Input).value.strip()
         if not name or not name.islower() or " " in name:
             self.app.bell()
             return
         base = Path("experiments")
+        inputs = None
+        if self.query_one("#graph", Checkbox).value:
+            exps = discover_objects(Path("."), OBJ_TYPES["experiment"])
+            mapping = await self.app.push_screen_wait(SelectInputsScreen(exps))
+            if mapping is None:
+                return
+            inputs = mapping
         try:
             create_experiment_scaffolding(
                 name,
@@ -60,8 +75,73 @@ class CreateExperimentScreen(ModalScreen[None]):
                 outputs=self.query_one("#outputs", Checkbox).value,
                 hypotheses=self.query_one("#hypotheses", Checkbox).value,
                 examples=self.query_one("#examples", Checkbox).value,
+                input_artifacts=inputs,
             )
         except FileExistsError:
             self.app.bell()
             return
+        self.dismiss(None)
+
+
+class SelectInputsScreen(ModalScreen[dict[str, str] | None]):
+    """Allow the user to choose outputs from existing experiments."""
+
+    BINDINGS = [
+        ("ctrl+c", "cancel", "Cancel"),
+        ("q", "cancel", "Close"),
+        ("enter", "confirm", "Confirm"),
+    ]
+
+    def __init__(self, experiments: dict[str, Experiment]) -> None:
+        super().__init__()
+        self._experiments = experiments
+        self._current: str | None = None
+
+    def compose(self) -> ComposeResult:
+        with Container():
+            yield Static("Select experiment inputs", id="modal-title")
+            with Container(id="input-select"):
+                self.exp_list = OptionList(id="exp-list")
+                for name in self._experiments:
+                    self.exp_list.add_option(Selection(name, name))
+                self.out_list = ActionableSelectionList(id="out-list")
+                yield self.exp_list
+                yield self.out_list
+            yield Button("Confirm", id="confirm")
+            yield Button("Cancel", id="cancel")
+
+    def on_mount(self) -> None:
+        if self.exp_list.options:
+            first = self.exp_list.options[0]
+            self._current = first.id if hasattr(first, "id") else first.value
+            self._update_outputs(self._current)
+        self.exp_list.focus()
+
+    def _update_outputs(self, exp: str) -> None:
+        self.out_list.clear_options()
+        for out in self._experiments[exp].outputs:
+            self.out_list.add_option(Selection(out, out))
+
+    def on_option_list_option_selected(
+        self, message: OptionList.OptionSelected
+    ) -> None:
+        self._current = message.option.id
+        self._update_outputs(message.option.id)
+
+    def action_confirm(self) -> None:
+        if self._current is None:
+            self.dismiss(None)
+            return
+        selected = [o for o in self.out_list.selected if isinstance(o, int)]
+        outputs = list(self._experiments[self._current].outputs)
+        mapping = {outputs[i]: f"{self._current}#{outputs[i]}" for i in selected}
+        self.dismiss(mapping)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "confirm":
+            self.action_confirm()
+        else:
+            self.dismiss(None)
+
+    def action_cancel(self) -> None:
         self.dismiss(None)

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -87,8 +87,9 @@ def _write_summary(log: RichLog, result: Any) -> None:
         _write_experiment_summary(log, result)
 
 
-import yaml
 from pathlib import Path
+
+import yaml
 
 
 class IndentDumper(yaml.SafeDumper):
@@ -105,8 +106,18 @@ def create_experiment_scaffolding(
     outputs: bool = False,
     hypotheses: bool = False,
     examples: bool = False,
+    input_artifacts: dict[str, str] | None = None,
 ) -> Path:
-    """Create a new experiment folder with optional example code."""
+    """Create a new experiment folder with optional example code.
+
+    Parameters
+    ----------
+    name:
+        Name of the experiment directory.
+    input_artifacts:
+        Optional mapping of datasource aliases to ``"experiment#output"``
+        strings referencing outputs from other experiments.
+    """
 
     if not name or not name.islower() or " " in name:
         raise ValueError("name must be lowercase and contain no spaces")
@@ -121,9 +132,11 @@ def create_experiment_scaffolding(
         config["outputs"] = {}
     if hypotheses:
         config["hypotheses"] = []
+    if input_artifacts:
+        config["datasource"] = input_artifacts
 
     if examples:
-        if datasources:
+        if datasources and not input_artifacts:
             config["datasource"] = {"numbers": "numbers"}
         if steps:
             config["steps"] = ["add_one"]

--- a/tests/test_cli_create.py
+++ b/tests/test_cli_create.py
@@ -1,6 +1,7 @@
 from pathlib import Path
-import yaml
+
 import pytest
+import yaml
 
 from cli.utils import create_experiment_scaffolding
 
@@ -25,3 +26,16 @@ def test_create_with_examples(tmp_path: Path) -> None:
 def test_create_invalid_name(tmp_path: Path) -> None:
     with pytest.raises(ValueError):
         create_experiment_scaffolding("Bad Name", directory=tmp_path)
+
+
+def test_create_with_input_artifacts(tmp_path: Path) -> None:
+    mapping = {"prev": "other#out"}
+    path = create_experiment_scaffolding(
+        "consumer",
+        directory=tmp_path,
+        steps=False,
+        datasources=False,
+        input_artifacts=mapping,
+    )
+    cfg = yaml.safe_load((path / "config.yaml").read_text())
+    assert cfg["datasource"] == mapping


### PR DESCRIPTION
### Summary
- enable selecting outputs from other experiments when creating a new experiment
- support input artifact mappings in `create_experiment_scaffolding`
- test new scaffolding option

### Changes
- extend CLI experiment creation screen with graph option and new selection screen
- update scaffolding utility to accept `input_artifacts`
- add regression test for artifact datasource generation

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_68854f0c3de48329bf9aa186c6604afb