### PR TITLE
Add search and run controls to selection screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ Crystallize ships with an interactive CLI for discovering and executing
 experiments or experiment graphs. After each run, the summary screen now displays
 both recorded metrics and hypothesis results.
 
+Use the search field above each list to quickly filter experiments or graphs.
+Clicking an item shows its details in the right panel with a **Run** button to
+start execution. Pressing <kbd>Enter</kbd> while a list is focused also runs the
+selected object.
+
 Press ``c`` in the main screen to scaffold a new experiment folder.
 
 ```bash

--- a/cli/constants.py
+++ b/cli/constants.py
@@ -233,4 +233,14 @@ ListItem:hover {
     color: $error;
     margin-top: 1;
 }
+
+Input {
+    border: tall $secondary;
+    margin-bottom: 1;
+    width: 100%;
+}
+
+Input:focus {
+    border: tall $accent;
+}
 """

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from rich.table import Table
 from rich.text import Text
@@ -28,6 +28,12 @@ def _build_experiment_table(result: Any) -> Optional[Table]:
             row.append(str(metrics.treatments[t].metrics.get(name)))
         table.add_row(*row)
     return table
+
+
+def filter_mapping(mapping: Dict[str, Any], query: str) -> Dict[str, Any]:
+    """Return subset of mapping where key contains ``query`` (case-insensitive)."""
+    q = query.lower()
+    return {k: v for k, v in mapping.items() if q in k.lower()}
 
 
 def _build_hypothesis_tables(result: Any) -> list[Table]:

--- a/tests/test_cli_core.py
+++ b/tests/test_cli_core.py
@@ -10,6 +10,7 @@ from cli.utils import (
     _build_hypothesis_tables,
     _write_experiment_summary,
     _write_summary,
+    filter_mapping,
 )
 from crystallize import data_source, pipeline_step
 from crystallize.experiments.experiment import Experiment
@@ -255,3 +256,8 @@ def test_write_summary_dict():
     _write_summary(log, {"exp": res})
     assert any(str(m) == "exp" for m in log.written if not hasattr(m, "columns"))
     assert any(hasattr(m, "columns") for m in log.written)
+
+
+def test_filter_mapping():
+    data = {"ExpOne": 1, "Another": 2, "expTwo": 3}
+    assert filter_mapping(data, "exp") == {"ExpOne": 1, "expTwo": 3}


### PR DESCRIPTION
### Summary
- allow searching within experiment and graph lists
- show details when clicking with a separate Run button
- support running selection via Enter key
- style new inputs
- test filter helper

### Changes
- add search `Input` widgets and Run button
- update CLI selection logic and bindings
- introduce `filter_mapping` utility
- document new CLI behavior

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_68856eea300c8329b693a7fb91c18423