### PR TITLE
Implement selection lists for run and create screens

### DIFF
--- a/cli/screens/create_experiment.py
+++ b/cli/screens/create_experiment.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 from pathlib import Path
+
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.reactive import reactive
-from textual.widgets import Button, Checkbox, Collapsible, Input, Label, Static
 from textual.screen import ModalScreen
+from textual.widgets import Button, Collapsible, Input, Label, Static
+from textual.widgets.selection_list import Selection
 
 from ..utils import create_experiment_scaffolding
+from .selection_screens import ActionableSelectionList
 
 
 class CreateExperimentScreen(ModalScreen[None]):
@@ -33,33 +36,43 @@ class CreateExperimentScreen(ModalScreen[None]):
             )
             yield Label(id="name-feedback")  # For validation feedback
             with Collapsible(title="Files to include", collapsed=False):
-                yield Checkbox(
-                    "steps.py",
-                    value=True,
-                    id="steps",
-                    tooltip="Defines experiment steps and logic",
+                self.file_list = ActionableSelectionList(classes="files-to-include")
+                self.file_list.add_option(
+                    Selection(
+                        "steps.py",
+                        "steps",
+                        initial_state=True,
+                        id="steps",
+                        disabled=False,
+                    )
                 )
-                yield Checkbox(
-                    "datasources.py",
-                    value=True,
-                    id="datasources",
-                    tooltip="Handles data input sources",
+                self.file_list.add_option(
+                    Selection(
+                        "datasources.py",
+                        "datasources",
+                        initial_state=True,
+                        id="datasources",
+                    )
                 )
-                yield Checkbox(
-                    "outputs.py",
-                    id="outputs",
-                    tooltip="Manages experiment outputs and results",
+                self.file_list.add_option(
+                    Selection(
+                        "outputs.py",
+                        "outputs",
+                        id="outputs",
+                    )
                 )
-                yield Checkbox(
-                    "hypotheses.py",
-                    id="hypotheses",
-                    tooltip="Documents hypotheses and assumptions",
+                self.file_list.add_option(
+                    Selection(
+                        "hypotheses.py",
+                        "hypotheses",
+                        id="hypotheses",
+                    )
                 )
-            yield Checkbox(
-                "Add example code",
-                id="examples",
-                tooltip="Includes starter code in selected files",
+                yield self.file_list
+            self.examples = ActionableSelectionList(
+                Selection("Add example code", "examples", id="examples")
             )
+            yield self.examples
             with Horizontal(classes="button-row"):
                 yield Button("Create", variant="success", id="create")
                 yield Button("Cancel", variant="error", id="cancel")
@@ -96,15 +109,17 @@ class CreateExperimentScreen(ModalScreen[None]):
     def _create(self) -> None:
         name = self.query_one("#name-input", Input).value.strip()
         base = Path("experiments")
+        selections = set(self.file_list.selected)
+        examples = "examples" in self.examples.selected
         try:
             create_experiment_scaffolding(
                 name,
                 directory=base,
-                steps=self.query_one("#steps", Checkbox).value,
-                datasources=self.query_one("#datasources", Checkbox).value,
-                outputs=self.query_one("#outputs", Checkbox).value,
-                hypotheses=self.query_one("#hypotheses", Checkbox).value,
-                examples=self.query_one("#examples", Checkbox).value,
+                steps="steps" in selections,
+                datasources="datasources" in selections,
+                outputs="outputs" in selections,
+                hypotheses="hypotheses" in selections,
+                examples=examples,
             )
         except FileExistsError:
             self.app.bell()

--- a/cli/screens/prepare_run.py
+++ b/cli/screens/prepare_run.py
@@ -8,7 +8,7 @@ from typing import List, Tuple
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal
 from textual.screen import ModalScreen
-from textual.widgets import Button, Static
+from textual.widgets import Button, Static, SelectionList
 from textual.widgets.selection_list import Selection
 
 from .selection_screens import ActionableSelectionList, SingleSelectionList
@@ -36,6 +36,7 @@ class PrepareRunScreen(ModalScreen[tuple[str, tuple[int, ...]] | None]):
             self.options = SingleSelectionList(
                 Selection("rerun", "rerun", id="rerun"),
                 Selection("resume", "resume", id="resume"),
+                id="run-method",
             )
             yield self.options
             if self._deletable:
@@ -52,8 +53,8 @@ class PrepareRunScreen(ModalScreen[tuple[str, tuple[int, ...]] | None]):
     def on_mount(self) -> None:
         self.options.focus()
 
-    def on_single_selection_list_selected_changed(
-        self, message: SingleSelectionList.SelectedChanged
+    def on_selection_list_selected_changed(
+        self, message: SelectionList.SelectedChanged
     ) -> None:
         if message.selection_list.selected:
             self._strategy = str(message.selection_list.selected[0])
@@ -68,7 +69,7 @@ class PrepareRunScreen(ModalScreen[tuple[str, tuple[int, ...]] | None]):
         if event.button.id == "run":
             if self._strategy is None:
                 self.query_one("#run-feedback", Static).update(
-                    "[red]Select a run strategy to continue[/red]"
+                    f"[red]Select a run strategy to continue[/red]"
                 )
                 return
             selections: tuple[int, ...] = ()

--- a/cli/screens/prepare_run.py
+++ b/cli/screens/prepare_run.py
@@ -17,6 +17,8 @@ from .selection_screens import ActionableSelectionList, SingleSelectionList
 class PrepareRunScreen(ModalScreen[tuple[str, tuple[int, ...]] | None]):
     """Collect execution strategy and deletable artifacts."""
 
+    CSS_PATH = "style/prepare_run.tcss"
+
     BINDINGS = [
         ("ctrl+c", "cancel_and_exit", "Cancel"),
         ("escape", "cancel_and_exit", "Cancel"),
@@ -45,6 +47,7 @@ class PrepareRunScreen(ModalScreen[tuple[str, tuple[int, ...]] | None]):
             with Horizontal(classes="button-row"):
                 yield Button("Run", variant="success", id="run")
                 yield Button("Cancel", variant="error", id="cancel")
+            yield Static(id="run-feedback")
 
     def on_mount(self) -> None:
         self.options.focus()
@@ -64,6 +67,9 @@ class PrepareRunScreen(ModalScreen[tuple[str, tuple[int, ...]] | None]):
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "run":
             if self._strategy is None:
+                self.query_one("#run-feedback", Static).update(
+                    "[red]Select a run strategy to continue[/red]"
+                )
                 return
             selections: tuple[int, ...] = ()
             if hasattr(self, "list"):

--- a/cli/screens/prepare_run.py
+++ b/cli/screens/prepare_run.py
@@ -7,11 +7,11 @@ from typing import List, Tuple
 
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal
-from textual.widgets import Button, OptionList, Static
-from textual.widgets.selection_list import Selection
 from textual.screen import ModalScreen
+from textual.widgets import Button, Static
+from textual.widgets.selection_list import Selection
 
-from .selection_screens import ActionableSelectionList
+from .selection_screens import ActionableSelectionList, SingleSelectionList
 
 
 class PrepareRunScreen(ModalScreen[tuple[str, tuple[int, ...]] | None]):
@@ -31,9 +31,10 @@ class PrepareRunScreen(ModalScreen[tuple[str, tuple[int, ...]] | None]):
     def compose(self) -> ComposeResult:
         with Container(id="prepare-run-container"):
             yield Static("Configure Run", id="modal-title")
-            self.options = OptionList()
-            self.options.add_option(Selection("rerun", "rerun", id="rerun"))
-            self.options.add_option(Selection("resume", "resume", id="resume"))
+            self.options = SingleSelectionList(
+                Selection("rerun", "rerun", id="rerun"),
+                Selection("resume", "resume", id="resume"),
+            )
             yield self.options
             if self._deletable:
                 yield Static("Select data to delete (optional)", id="delete-info")
@@ -48,10 +49,11 @@ class PrepareRunScreen(ModalScreen[tuple[str, tuple[int, ...]] | None]):
     def on_mount(self) -> None:
         self.options.focus()
 
-    def on_option_list_option_selected(
-        self, message: OptionList.OptionSelected
+    def on_single_selection_list_selected_changed(
+        self, message: SingleSelectionList.SelectedChanged
     ) -> None:
-        self._strategy = message.option.id
+        if message.selection_list.selected:
+            self._strategy = str(message.selection_list.selected[0])
 
     def on_actionable_selection_list_submitted(
         self, message: ActionableSelectionList.Submitted

--- a/cli/screens/prepare_run.py
+++ b/cli/screens/prepare_run.py
@@ -34,8 +34,8 @@ class PrepareRunScreen(ModalScreen[tuple[str, tuple[int, ...]] | None]):
         with Container(id="prepare-run-container"):
             yield Static("Configure Run", id="modal-title")
             self.options = SingleSelectionList(
-                Selection("rerun", "rerun", id="rerun"),
                 Selection("resume", "resume", id="resume"),
+                Selection("rerun", "rerun", id="rerun"),
                 id="run-method",
             )
             yield self.options

--- a/cli/screens/selection_screens.py
+++ b/cli/screens/selection_screens.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from textual.message import Message
 from textual.widgets import SelectionList
+from textual.widgets.selection_list import Selection
 
 
 class ActionableSelectionList(SelectionList):
@@ -23,3 +24,22 @@ class ActionableSelectionList(SelectionList):
             value for value in self.selected if isinstance(value, int)
         )
         self.post_message(self.Submitted(selected_indices))
+
+
+class SingleSelectionList(ActionableSelectionList):
+    """A SelectionList that allows only a single selection."""
+
+    def select(self, selection: Selection | Any) -> "SingleSelectionList":
+        self.deselect_all()
+        return super().select(selection)
+
+    def toggle(self, selection: Selection | Any) -> "SingleSelectionList":
+        if selection in self.selected or (
+            isinstance(selection, Selection) and selection.value in self.selected
+        ):
+            self.deselect_all()
+        else:
+            self.deselect_all()
+            super().select(selection)
+        self.refresh()
+        return self

--- a/cli/screens/style/create_experiment.tcss
+++ b/cli/screens/style/create_experiment.tcss
@@ -37,15 +37,9 @@ Label {
     width: 100%;
 }
 
-Checkbox {
+SelectionList {
     margin: 0 0 1 0;
     width: 100%;
-    content-align: left middle;
-    min-width: 20;  /* Ensures enough space for longer labels */
-}
-
-Checkbox:hover {
-    background: $accent-darken-1;
 }
 
 .button-row {

--- a/cli/screens/style/prepare_run.tcss
+++ b/cli/screens/style/prepare_run.tcss
@@ -1,4 +1,4 @@
-#create-exp-container {
+#prepare-run-container {
     layout: vertical;
     width: 70%;
     height: auto;
@@ -14,27 +14,6 @@
     text-style: bold;
     color: $accent;
     margin-bottom: 1;
-}
-
-Input {
-    border: tall $secondary;
-    margin: 1 0;
-    width: 100%;
-}
-
-Input:focus {
-    border: tall $accent;
-}
-
-Label {
-    color: $text-muted;
-    margin: 0 0 1 0;
-}
-
-.files-to-include {
-    height: auto;
-    margin: 1 0;
-    width: 100%;
 }
 
 SelectionList {
@@ -56,8 +35,7 @@ Button:hover {
     background: $accent;
 }
 
-#name-feedback {
+#run-feedback {
     height: 1;
     color: $text-muted;
 }
-


### PR DESCRIPTION
### Summary
- switch run strategy options to SingleSelectionList
- use ActionableSelectionList in the create experiment dialog
- adapt styles for SelectionList widgets

### Changes
- replace OptionList with SingleSelectionList in PrepareRunScreen
- add SingleSelectionList helper
- refactor CreateExperimentScreen to use SelectionList widgets
- update CSS for selection lists

### Testing & Verification
- `isort` and `black` formatting applied
- `mypy` run but reported missing stubs
- `pytest` failed due to missing optional dependencies
- `coverage` and diff coverage could not be generated

### Notes
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68857d53358c8329a95cd044285f059e