### PR TITLE
Handle baseline-named treatments

### DIFF
--- a/crystallize/plugins/execution.py
+++ b/crystallize/plugins/execution.py
@@ -65,8 +65,10 @@ class ParallelExecution(BasePlugin):
             exec_cls = ProcessPoolExecutor
             submit_target = _run_replicate_remote
             treatments = getattr(experiment, "treatments", [])
+            baseline_treatment = getattr(experiment, "_baseline_treatment", None)
             arg_list = [
-                (experiment, rep, treatments) for rep in range(experiment.replicates)
+                (experiment, rep, treatments, baseline_treatment)
+                for rep in range(experiment.replicates)
             ]
         else:  # 'thread'
             default_workers = os.cpu_count() or 8

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -136,6 +136,21 @@ def test_experiment_run_treatments_no_hypotheses():
     assert result.metrics.treatments["treat"].metrics["metric"] == [1]
 
 
+def test_treatment_named_baseline_updates_baseline():
+    pipeline = Pipeline([PassStep()])
+    datasource = DummyDataSource()
+    baseline_t = Treatment("baseline", {"increment": 2})
+
+    experiment = Experiment(
+        datasource=datasource,
+        pipeline=pipeline,
+    )
+    experiment.validate()
+    result = experiment.run(treatments=[baseline_t])
+    assert result.metrics.baseline.metrics["metric"] == [2]
+    assert "baseline" not in result.metrics.treatments
+
+
 def test_experiment_run_hypothesis_without_treatments_raises():
     pipeline = Pipeline([PassStep()])
     datasource = DummyDataSource()
@@ -612,6 +627,7 @@ def test_process_pool_respects_max_workers(monkeypatch):
     from crystallize.experiments.run_results import ReplicateResult
 
     def dummy_remote(args):
+        # args now include baseline_treatment as last element
         return ReplicateResult(None, None, {}, {}, {}, {})
 
     monkeypatch.setattr(


### PR DESCRIPTION
### Summary
- allow passing a treatment named `baseline`
- run this treatment as the baseline condition
- keep parallel execution aware of this baseline treatment
- add regression test

### Changes
- modify `_execute_replicate` to accept `baseline_treatment`
- store baseline treatment during runtime
- wire through to parallel execution
- test that baseline treatment populates baseline metrics

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_688587754dc88329918e47eb164ea0b4