### PR TITLE
feat(crystallize-ml): recursive graph loading

### DIFF
--- a/docs/src/content/docs/how-to/dag-experiments.md
+++ b/docs/src/content/docs/how-to/dag-experiments.md
@@ -41,3 +41,12 @@ You can also scaffold a graph-aware experiment using the interactive CLI. Press
 ``c`` on the main screen and enable *Use outputs from other experiments*. Select
 the upstream experiment and choose which outputs should become inputs. The CLI
 adds them to ``config.yaml`` as ``experiment#output`` strings.
+
+You can load such a workflow directly from the final experiment's YAML file:
+
+```python
+from crystallize import ExperimentGraph
+
+graph = ExperimentGraph.from_yaml("experiments/final/config.yaml")
+ExperimentGraph.visualize_from_yaml("experiments/final/config.yaml")
+```

--- a/examples/folder_experiment/main.py
+++ b/examples/folder_experiment/main.py
@@ -1,8 +1,13 @@
 from pathlib import Path
 from crystallize.experiments.experiment import Experiment
+from crystallize.experiments.experiment_graph import ExperimentGraph
 
 if __name__ == "__main__":
     exp = Experiment.from_yaml(Path(__file__).parent / "config.yaml")
     exp.validate()
     res = exp.run()
     print(res.metrics.baseline.metrics)
+
+    # Build a graph from the same YAML and visualize dependencies
+    graph = ExperimentGraph.from_yaml(Path(__file__).parent / "config.yaml")
+    ExperimentGraph.visualize_from_yaml(Path(__file__).parent / "config.yaml")


### PR DESCRIPTION
### Summary
- support recursive ExperimentGraph YAML loading with `from_yaml`
- add `visualize_from_yaml` helper
- update docs and folder example to show graph loading
- test recursive loading and error handling

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_6885b68ee67483298f9e5a92e5e2fc53