### PR TITLE
Use YAML-based discovery in CLI

### DIFF
--- a/crystallize/experiments/experiment.py
+++ b/crystallize/experiments/experiment.py
@@ -901,7 +901,11 @@ class Experiment:
                 module_name = ".".join(rel.with_suffix("").parts)
                 if str(root) not in sys.path:
                     sys.path.insert(0, str(root))
-                module = import_module(module_name)
+
+                if module_name in sys.modules:
+                    module = importlib.reload(sys.modules[module_name])
+                else:
+                    module = importlib.import_module(module_name)
             except ValueError:
                 spec = importlib.util.spec_from_file_location(mod_path.stem, mod_path)
                 if spec and spec.loader:

--- a/crystallize/experiments/experiment.py
+++ b/crystallize/experiments/experiment.py
@@ -884,7 +884,6 @@ class Experiment:
     def from_yaml(cls, config_path: str | Path) -> "Experiment":
         """Instantiate an experiment from a folder-based YAML config."""
 
-        from importlib import import_module
         import yaml
 
         path = Path(config_path)

--- a/tests/test_cli_yaml_discovery.py
+++ b/tests/test_cli_yaml_discovery.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import yaml
+
+from cli.discovery import discover_configs
+
+
+def test_yaml_discovery(tmp_path: Path) -> None:
+    exp_dir = tmp_path / "exp"
+    exp_dir.mkdir()
+    cfg1 = {"name": "exp", "datasource": {"n": "numbers"}}
+    (exp_dir / "config.yaml").write_text(yaml.safe_dump(cfg1))
+
+    graph_dir = tmp_path / "graph"
+    graph_dir.mkdir()
+    cfg2 = {"name": "graph", "datasource": {"data": "exp#out"}}
+    (graph_dir / "config.yaml").write_text(yaml.safe_dump(cfg2))
+
+    graphs, experiments, errors = discover_configs(tmp_path)
+
+    graph_paths = {info["path"] for info in graphs.values()}
+    exp_paths = {info["path"] for info in experiments.values()}
+
+    assert (graph_dir / "config.yaml") in graph_paths
+    assert (exp_dir / "config.yaml") in exp_paths
+    assert not errors


### PR DESCRIPTION
### Summary
Switch CLI experiment discovery to parse `config.yaml` files instead of importing every `.py` file. Experiments are loaded only when run is triggered.

### Changes
- add `discover_configs` helper for YAML scanning
- refactor `SelectionScreen` to use YAML discovery and JIT loading
- add unit test for YAML discovery

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_6885d51f45488329902de715a1c3c58c