### PR TITLE
Add YAML info summary to selection screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ both recorded metrics and hypothesis results.
 
 Use the search field above each list to quickly filter experiments or graphs.
 Clicking an item shows its details in the right panel with a **Run** button to
-start execution. Pressing <kbd>Enter</kbd> while a list is focused also runs the
-selected object.
+start execution. The details panel summarizes key values from the YAML
+configuration (replicates, step count, datasource keys). Pressing <kbd>Enter</kbd>
+while a list is focused also runs the selected object.
 
 Press ``c`` in the main screen to scaffold a new experiment folder.
 

--- a/cli/discovery.py
+++ b/cli/discovery.py
@@ -108,12 +108,43 @@ def discover_configs(
                 data = yaml.safe_load(f) or {}
             name = data.get("name", cfg.parent.name)
             desc = data.get("description", "")
+            info_lines = []
+            if desc:
+                info_lines.append(desc)
+            if "replicates" in data:
+                info_lines.append(f"Replicates: {data['replicates']}")
+            if "steps" in data:
+                steps = data["steps"]
+                count = len(steps) if isinstance(steps, list) else 0
+                info_lines.append(f"Steps: {count}")
+            datasource = data.get("datasource")
+            if datasource is not None:
+                if isinstance(datasource, dict):
+                    info_lines.append(
+                        "Datasource: " + ", ".join(sorted(datasource.keys()))
+                    )
+                else:
+                    info_lines.append("Datasource: configured")
+            if "treatments" in data:
+                tr = data["treatments"]
+                count = len(tr) if isinstance(tr, (list, dict)) else 0
+                info_lines.append(f"Treatments: {count}")
+            if "outputs" in data and isinstance(data["outputs"], dict):
+                info_lines.append(f"Outputs: {len(data['outputs'])}")
+            summary = (
+                "\n".join(info_lines) if info_lines else "No description available."
+            )
             try:
                 rel = cfg.parent.relative_to(cwd)
             except ValueError:
                 rel = cfg.parent
             label = f"{rel} - {name}"
-            info = {"path": cfg, "description": desc, "label": label}
+            info = {
+                "path": cfg,
+                "description": desc,
+                "summary": summary,
+                "label": label,
+            }
             is_graph = _has_ref(data.get("datasource"))
             if is_graph:
                 graphs[label] = info

--- a/cli/screens/selection.py
+++ b/cli/screens/selection.py
@@ -133,7 +133,7 @@ class SelectionScreen(Screen):
                     "path": info["path"],
                     "label": label,
                     "type": "Graph",
-                    "doc": info["description"] or "No description available.",
+                    "doc": info["summary"],
                 }
 
             initial_tab = "graphs"
@@ -162,7 +162,7 @@ class SelectionScreen(Screen):
                     "path": info["path"],
                     "label": label,
                     "type": "Experiment",
-                    "doc": info["description"] or "No description available.",
+                    "doc": info["summary"],
                 }
 
             if initial_tab is None:

--- a/tests/test_cli_yaml_discovery.py
+++ b/tests/test_cli_yaml_discovery.py
@@ -24,3 +24,23 @@ def test_yaml_discovery(tmp_path: Path) -> None:
     assert (graph_dir / "config.yaml") in graph_paths
     assert (exp_dir / "config.yaml") in exp_paths
     assert not errors
+
+
+def test_yaml_discovery_summary(tmp_path: Path) -> None:
+    exp_dir = tmp_path / "exp"
+    exp_dir.mkdir()
+    cfg = {
+        "name": "exp",
+        "description": "my experiment",
+        "replicates": 3,
+        "datasource": {"n": "numbers"},
+        "steps": ["a", "b"],
+        "treatments": {"a": {}},
+        "outputs": {"o": {}},
+    }
+    (exp_dir / "config.yaml").write_text(yaml.safe_dump(cfg))
+
+    _, experiments, _ = discover_configs(tmp_path)
+    info = next(iter(experiments.values()))
+    assert "Replicates: 3" in info["summary"]
+    assert "Steps: 2" in info["summary"]


### PR DESCRIPTION
### Summary
- show configuration summary in SelectionScreen details
- extract YAML summary when discovering configs
- test discover_configs summary helper
- document CLI details panel improvements

### Testing & Verification
- `pixi run lint` *(fails: No such command 'run')*
- `pixi run test` *(fails: No such command 'run')*
- `pixi run cov` *(fails: No such command 'run')*
- `pixi run diff-cov` *(fails: No such command 'run')*


------
https://chatgpt.com/codex/tasks/task_e_6885ef9b9f08832989045571ba9619ab