### PR TITLE
Add editable replicates in selection screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,10 @@ The selection screen now groups experiments and graphs into collapsible trees
 using these settings. Clicking a node shows its details in the right panel with
 a **Run** button. Press <kbd>Enter</kbd> to run the highlighted object.
 
-Press ``c`` in the main screen to scaffold a new experiment folder.
+Press ``c`` in the main screen to scaffold a new experiment folder. The details
+panel also displays the current replicate count from each ``config.yaml``. Edit
+the number in the input field and press <kbd>Enter</kbd> to save it back to the
+file.
 
 ```bash
 # Discover and run a single experiment

--- a/cli/discovery.py
+++ b/cli/discovery.py
@@ -108,6 +108,7 @@ def discover_configs(
                 data = yaml.safe_load(f) or {}
             name = data.get("name", cfg.parent.name)
             desc = data.get("description", "")
+            repl = data.get("replicates", 1)
             cli_cfg = data.get("cli", {}) or {}
 
             is_graph = _has_ref(data.get("datasource"))
@@ -133,6 +134,7 @@ def discover_configs(
             info = {
                 "path": cfg,
                 "description": desc,
+                "replicates": repl,
                 "label": label,
                 "cli": cli_info,
             }

--- a/cli/screens/selection.py
+++ b/cli/screens/selection.py
@@ -13,6 +13,7 @@ from textual.widgets import (
     Button,
     Footer,
     Header,
+    Input,
     LoadingIndicator,
     Static,
     Tree,
@@ -25,6 +26,7 @@ from ..constants import ASCII_ART_ARRAY
 from ..discovery import discover_configs
 from ..screens.create_experiment import CreateExperimentScreen
 from ..screens.run import _launch_run
+from ..utils import update_replicates
 
 
 class SelectionScreen(Screen):
@@ -43,6 +45,16 @@ class SelectionScreen(Screen):
         self._experiments: Dict[str, Dict[str, Any]] = {}
         self._graphs: Dict[str, Dict[str, Any]] = {}
         self._selected_obj: Dict[str, Any] | None = None
+
+    def _update_details(self, data: Dict[str, Any]) -> None:
+        details = self.query_one("#details", Static)
+        info = yaml.safe_load(Path(data["path"]).read_text()) or {}
+        repl = info.get("replicates", data.get("replicates", 1))
+        details.update(
+            f"[bold]Type: {data['type']}[/bold]\n\n{data['doc']}\nReplicates: {repl}"
+        )
+        rep_input = self.query_one("#replicate-input", Input)
+        rep_input.value = str(repl)
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -126,6 +138,7 @@ class SelectionScreen(Screen):
         right_panel = Container(classes="right-panel")
         await horizontal.mount(right_panel)
         await right_panel.mount(Static(id="details", classes="details-panel"))
+        await right_panel.mount(Input(id="replicate-input", placeholder="replicates"))
         await right_panel.mount(Button("Run", id="run-btn"))
 
         if self._load_errors:
@@ -162,15 +175,13 @@ class SelectionScreen(Screen):
     async def on_tree_node_highlighted(self, event: Tree.NodeHighlighted) -> None:
         if event.node.data is not None:
             data = event.node.data
-            details = self.query_one("#details", Static)
-            details.update(f"[bold]Type: {data['type']}[/bold]\n\n{data['doc']}")
+            self._update_details(data)
             self._selected_obj = data
 
     async def on_tree_node_selected(self, event: Tree.NodeSelected) -> None:
         if event.node.data is not None:
             data = event.node.data
-            details = self.query_one("#details", Static)
-            details.update(f"[bold]Type: {data['type']}[/bold]\n\n{data['doc']}")
+            self._update_details(data)
             self._selected_obj = data
 
     def action_show_errors(self) -> None:
@@ -182,3 +193,14 @@ class SelectionScreen(Screen):
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "run-btn":
             self.action_run_selected()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id == "replicate-input" and self._selected_obj is not None:
+            try:
+                new_val = int(event.value)
+            except ValueError:
+                self.app.bell()
+                return
+            update_replicates(Path(self._selected_obj["path"]), new_val)
+            self._selected_obj["replicates"] = new_val
+            self._update_details(self._selected_obj)

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -205,3 +205,15 @@ def create_experiment_scaffolding(
     (exp_dir / "main.py").write_text(main_code)
 
     return exp_dir
+
+
+def update_replicates(config_path: Path, replicates: int) -> None:
+    """Update the replicates count in ``config_path``."""
+
+    with config_path.open() as f:
+        data = yaml.safe_load(f) or {}
+
+    data["replicates"] = replicates
+
+    with config_path.open("w") as f:
+        yaml.dump(data, f, Dumper=IndentDumper, sort_keys=False)

--- a/tests/test_cli_yaml_discovery.py
+++ b/tests/test_cli_yaml_discovery.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import yaml
 
 from cli.discovery import discover_configs
+from cli.utils import update_replicates
 
 
 def test_yaml_discovery(tmp_path: Path) -> None:
@@ -12,6 +13,7 @@ def test_yaml_discovery(tmp_path: Path) -> None:
         "name": "exp",
         "datasource": {"n": "numbers"},
         "cli": {"group": "Data", "priority": 1, "icon": "X", "color": "#111111"},
+        "replicates": 5,
     }
     (exp_dir / "config.yaml").write_text(yaml.safe_dump(cfg1))
 
@@ -45,10 +47,25 @@ def test_yaml_discovery(tmp_path: Path) -> None:
     assert info["cli"]["priority"] == 1
     assert info["cli"]["icon"] == "X"
     assert info["cli"]["color"] == "#111111"
+    assert info["replicates"] == 5
     default_key = next(
         k for k, v in experiments.items() if v["path"] == other / "config.yaml"
     )
     default_info = experiments[default_key]
     assert default_info["cli"]["group"] == "Experiments"
     assert default_info["cli"]["icon"] == "🧪"
+    assert default_info["replicates"] == 1
     assert not errors
+
+
+def test_update_replicates(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    with cfg.open("w") as f:
+        yaml.safe_dump({"name": "e", "datasource": {"n": "numbers"}}, f)
+
+    update_replicates(cfg, 7)
+
+    with cfg.open() as f:
+        data = yaml.safe_load(f)
+
+    assert data["replicates"] == 7


### PR DESCRIPTION
### Summary
- display replicates from `config.yaml` in selection screen
- allow editing replicates and saving back to YAML
- expose helper to update replicates
- document replicates editing in README

### Changes
- parse `replicates` in `discover_configs`
- add input field on selection screen and update handler
- new utility `update_replicates`
- tests for discovery and updating replicates

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_6885f1a1f1c483299e8ad8a70987e0e6