### PR TITLE
Add help popup for config editor

### DIFF
--- a/cli/widgets/config_editor.py
+++ b/cli/widgets/config_editor.py
@@ -190,6 +190,40 @@ class ConfigTree(Tree):
             node.add_leaf(str(value), data=path)
 
 
+class ConfigHelpScreen(ModalScreen[None]):
+    """Popup explaining root config properties."""
+
+    CSS_PATH = "style/config_editor.tcss"
+
+    BINDINGS = [
+        Binding("ctrl+c", "close", "Close", show=False),
+        Binding("q", "close", "Close", show=False),
+        Binding("escape", "close", "Close"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        with Container(id="help-container"):
+            yield Static("Configuration Help", id="modal-title")
+            help_text = "\n".join(
+                [
+                    "`name` - experiment name used for artifact storage",
+                    "`replicates` - number of runs per treatment",
+                    "`datasource` - mapping of data sources or experiment outputs",
+                    "`steps` - ordered list of pipeline step names",
+                    "`outputs` - optional artifact definitions",
+                    "`hypotheses` - list of hypotheses to verify",
+                    "`treatments` - context modifications for each variant",
+                    "`cli` - CLI display metadata (group, icon, etc.)",
+                ]
+            )
+            yield Static(help_text, id="help-text")
+            yield Button("Close", id="close")
+        yield Footer()
+
+    def action_close(self) -> None:
+        self.dismiss(None)
+
+
 class ConfigEditorWidget(Container):
     """Widget for editing a config YAML file."""
 
@@ -197,6 +231,7 @@ class ConfigEditorWidget(Container):
         Binding("e", "edit", "Edit"),
         Binding("k", "move_up", "Move Up"),
         Binding("j", "move_down", "Move Down"),
+        Binding("h", "help", "Help"),
     ]
 
     def __init__(self, path: Path) -> None:
@@ -255,6 +290,9 @@ class ConfigEditorWidget(Container):
 
     def action_move_down(self) -> None:
         self._move_selected(1)
+
+    async def action_help(self) -> None:
+        await self.app.push_screen(ConfigHelpScreen())
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         self.remove()

--- a/docs/src/content/docs/how-to/dag-experiments.md
+++ b/docs/src/content/docs/how-to/dag-experiments.md
@@ -42,6 +42,8 @@ You can also scaffold a graph-aware experiment using the interactive CLI. Press
 tree lists available experiments. Expand a node to see its outputs and press
 <kbd>Space</kbd> to select them. The CLI adds your selections to ``config.yaml``
 as ``experiment#output`` strings.
+Press <kbd>h</kbd> in the configuration editor for a short explanation of each
+root property and its purpose.
 
 You can load such a workflow directly from the final experiment's YAML file:
 

--- a/tests/test_config_widget.py
+++ b/tests/test_config_widget.py
@@ -78,3 +78,22 @@ async def test_add_placeholders(
 
         text = (tmp_path / fname).read_text()
         assert fragment in text
+
+
+@pytest.mark.asyncio
+async def test_help_screen(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(yaml.safe_dump({"name": "e"}))
+    async with App().run_test() as pilot:
+        widget = ConfigEditorWidget(cfg)
+        await pilot.app.mount(widget)
+
+        screens: list[str] = []
+
+        async def fake_push(screen):
+            screens.append(type(screen).__name__)
+
+        widget.app.push_screen = fake_push  # type: ignore[assignment]
+        await widget.action_help()
+
+        assert "ConfigHelpScreen" in screens


### PR DESCRIPTION
### Summary
Adds an in-CLI help window describing experiment configuration fields.

### Changes
- new `ConfigHelpScreen` to explain YAML root properties
- `h` binding in `ConfigEditorWidget` opens the help screen
- updated docs with instruction for the new help key
- test ensuring help popup is triggered

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_68872db914f0832984f0ec03f97e9df7