### PR TITLE
Add initial CLI tutorial

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -24,7 +24,7 @@ export default defineConfig({
           items: [
             { label: 'Tutorial: Your First CLI Experiment', slug: 'cli/tutorial-cli-workflow' },
             { label: 'How-To: Configure Experiments (config.yaml)', slug: 'cli/how-to-configure' },
-            { label: 'How-To: Interactive Management', slug: 'cli/how-to-interactive' },
+            { label: 'Putting It All Together - Building a Graph Experiment', slug: 'cli/tutorial-graph-experiment' },
           ],
         },
         {

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -20,6 +20,14 @@ export default defineConfig({
       ],
       sidebar: [
         {
+          label: 'The Crystallize CLI',
+          items: [
+            { label: 'Tutorial: Your First CLI Experiment', slug: 'cli/tutorial-cli-workflow' },
+            { label: 'How-To: Configure Experiments (config.yaml)', slug: 'cli/how-to-configure' },
+            { label: 'How-To: Interactive Management', slug: 'cli/how-to-interactive' },
+          ],
+        },
+        {
           label: 'How-to Guides',
           items: [
             {

--- a/docs/src/content/docs/cli/how-to-configure.md
+++ b/docs/src/content/docs/cli/how-to-configure.md
@@ -1,0 +1,192 @@
+---
+title: "How-To: Configure Experiments (config.yaml)"
+description: A detailed reference guide for every section of the experiment config.yaml file.
+---
+
+The `config.yaml` file is the heart of any Crystallize experiment managed via the CLI. It's a declarative blueprint that tells the framework how to construct and run your experiment. This guide serves as a reference for each section of the file.
+
+## Anatomy of `config.yaml`
+
+A complete `config.yaml` is composed of several key sections. While not all are required for every experiment, they provide a powerful way to define your entire workflow.
+
+```yaml
+# Top-level settings
+name: my-experiment
+replicates: 10
+
+# CLI display settings
+cli:
+  group: My Experiments
+  priority: 1
+  icon: "🧪"
+
+# Data input definitions
+datasource:
+  # ...
+
+# The processing pipeline
+steps:
+  # ...
+
+# Named file outputs
+outputs:
+  # ...
+
+# Experimental variations
+treatments:
+  # ...
+
+# Statistical tests
+hypotheses:
+  # ...
+```
+
+### Top-Level Settings
+These define the fundamental properties of your experiment.
+- `name` *(string)*: The unique identifier for the experiment. If not provided, the folder name is used.
+- `replicates` *(integer)*: The number of times to run the pipeline for the baseline and each treatment. Defaults to `1`.
+
+```yaml
+name: titanic-age-analysis
+replicates: 20
+```
+
+### `cli`
+This section controls how your experiment appears in the interactive TUI.
+- `group` *(string)*: The name of the collapsible group this experiment appears under.
+- `priority` *(integer)*: A number used for sorting experiments within a group (lower numbers appear first).
+- `icon` *(string)*: An emoji or character displayed next to the experiment name.
+- `color` *(string, optional)*: A hex color code (e.g., "#85C1E9") to style the experiment's label.
+- `hidden` *(boolean)*: If `true`, the experiment will not be discovered by the CLI.
+
+```yaml
+cli:
+  group: Data Preprocessing
+  priority: 5
+  icon: "📊"
+  color: "#85C1E9"
+```
+
+### `datasource`
+Defines the input data for your pipeline. The structure depends on whether you are running a standard experiment or a graph that consumes artifacts from another experiment.
+
+**Standard Experiment**: A dictionary mapping a key to the name of a `@data_source` function in your `datasources.py` file.
+```yaml
+# Fetches data using the `titanic_ages` function in `datasources.py`
+datasource:
+  ages: titanic_ages
+```
+
+**Graph Experiment**: A dictionary mapping a key to a special `experiment_name#output_name` string. This tells Crystallize to use an artifact from another experiment as input.
+```yaml
+# Uses the 'out' artifact from the 'test' experiment as input
+datasource:
+  in: test#out
+```
+
+### `steps`
+A list defining the sequence of operations in your pipeline. Each item maps to a `@pipeline_step` function in your `steps.py` file.
+
+```yaml
+steps:
+  - calculate_mean_age
+  - normalize_data
+```
+
+A step can optionally return a tuple `(data, metrics_dict)` to record metrics. The first element is the data passed to the next step, and the second is a dictionary of metrics that will be available for hypotheses.
+
+```python
+# In steps.py
+@pipeline_step()
+def calculate_mean_age(data: pd.DataFrame):
+    mean_age = data['Age'].mean()
+    return data, {"mean_age": mean_age}
+```
+
+### `outputs`
+A dictionary defining named file artifacts that your steps can write to. This is necessary for experiments that produce files to be consumed by other experiments in a graph.
+
+To use an output, a pipeline step's function signature must include a parameter that has the same name as the output's alias and is type-hinted as `Artifact`.
+
+```yaml
+outputs:
+  model_file:
+    file_name: model.pkl
+```
+
+```python
+# In steps.py, the parameter `model_file` matches the alias
+from crystallize import pipeline_step, Artifact
+
+@pipeline_step()
+def train_model(data, *, model_file: Artifact):
+    model = ...  # train your model
+    model_file.write(model)  # Saves the model
+    return data
+```
+
+#### Consuming Artifacts in Another Experiment
+When another experiment uses this output via the datasource graph syntax, the data passed to its first step will be a dictionary mapping the datasource key to the artifact's file path.
+
+```yaml
+# In consumer-experiment/config.yaml
+name: consumer-experiment
+datasource:
+  trained_model: producer-experiment#model_file
+steps:
+  - evaluate_model
+```
+
+```python
+# In consumer-experiment/steps.py
+from pathlib import Path
+import pickle
+
+@pipeline_step()
+def evaluate_model(data: dict):
+    model_path = data['trained_model']
+    with open(model_path, 'rb') as f:
+        model = pickle.load(f)
+    return ...
+```
+
+### `treatments`
+Defines the experimental variations to test against the baseline. The values provided here are injected directly as parameters into your pipeline steps.
+
+```yaml
+treatments:
+  baseline:
+    delta: 0
+  add_two:
+    delta: 2
+```
+
+```python
+@pipeline_step()
+def add_delta(data, *, delta: int = 0):
+    return [x + delta for x in data]
+```
+
+### `hypotheses`
+A list of statistical tests to run on the collected metrics after all replicates are complete.
+
+```yaml
+hypotheses:
+  - name: check_mean_difference
+    verifier: welch_t_test
+    metrics: mean_age
+```
+
+```python
+from crystallize import verifier
+from scipy.stats import ttest_ind
+
+@verifier
+def welch_t_test(baseline_samples, treatment_samples, alpha: float = 0.05):
+    stat, p = ttest_ind(
+        treatment_samples['mean_age'],
+        baseline_samples['mean_age'],
+        equal_var=False
+    )
+    return {"p_value": p, "significant": p < alpha}
+```

--- a/docs/src/content/docs/cli/how-to-interactive.md
+++ b/docs/src/content/docs/cli/how-to-interactive.md
@@ -1,0 +1,6 @@
+---
+title: "How-To: Interactive Management"
+description: An overview of navigating the Crystallize TUI to manage experiments.
+---
+
+This page will cover interactive management of experiments using the built-in TUI. Content is under development.

--- a/docs/src/content/docs/cli/how-to-interactive.md
+++ b/docs/src/content/docs/cli/how-to-interactive.md
@@ -1,6 +1,0 @@
----
-title: "How-To: Interactive Management"
-description: An overview of navigating the Crystallize TUI to manage experiments.
----
-
-This page will cover interactive management of experiments using the built-in TUI. Content is under development.

--- a/docs/src/content/docs/cli/tutorial-cli-workflow.md
+++ b/docs/src/content/docs/cli/tutorial-cli-workflow.md
@@ -1,0 +1,50 @@
+---
+title: "Tutorial: Your First CLI Experiment"
+description: A complete walkthrough of creating, configuring, and running an experiment from the command line.
+---
+
+Welcome! This tutorial will guide you through the recommended workflow for using Crystallize: the interactive Command Line Interface (CLI). We'll build a complete experiment from scratch without writing boilerplate code, letting the TUI do the heavy lifting.
+
+### Step 1: Scaffold a New Experiment 🏗️
+
+First, let's create the file structure for our experiment.
+
+1.  Launch the interactive TUI from your terminal:
+    ```bash
+    crystallize
+    ```
+2.  From the main selection screen, press the <kbd>n</kbd> key.
+3.  This opens the **Create New Experiment** screen. Give your experiment a name (e.g., `my-cli-experiment`), ensure the default files are selected, and press the "Create" button.
+
+Crystallize will generate a new folder at `experiments/my-cli-experiment/` containing a default `config.yaml` and the necessary Python files (`steps.py`, `datasources.py`, etc.).
+
+### Step 2: Interactive Configuration ✍️
+
+The TUI makes editing your experiment's configuration simple.
+
+1.  **Select Your Experiment:** The main screen will now show `my-cli-experiment`. As it's highlighted, the right-hand panel displays its configuration in a live tree editor.
+2.  **Add a New Step:** Let's add a new processing step to the pipeline.
+    * Use the arrow keys to navigate the config tree on the right. Go down to `steps`.
+    * Highlight the `+ add step` item and press <kbd>Enter</kbd>.
+    * In the pop-up, enter the name `process_data` and save.
+3.  **The Magic ✨:** When you save, two things happen automatically:
+    * `process_data` is added to the `steps` list in your `config.yaml`.
+    * A placeholder function `def process_data(...):` is scaffolded in `experiments/my-cli-experiment/steps.py`.
+
+This allows you to design your pipeline declaratively. Now, open `steps.py` in your editor and add your logic to the placeholder function.
+
+### Step 3: Running the Experiment 📊
+
+Once your configuration and step logic are ready, it's time to run.
+
+1.  **Launch the Run:** In the TUI's left panel, ensure your experiment is highlighted and press <kbd>Enter</kbd>.
+2.  **Choose a Strategy:** The **Prepare Run** screen appears. This is a crucial step where you decide how to execute:
+    * `rerun`: Executes everything from scratch. Use this for final runs or when you know the cache is invalid.
+    * `resume`: Skips any steps that have already been completed successfully with the same inputs. This is perfect for iterating quickly after a failure or when you've only changed a downstream step.
+3.  **Enable Minimal Targets:** For the first run, toggle on only `data_sources` and `steps` in the left panel, leaving the other sections off.
+4.  **Start the Run:** Select the `rerun` option and confirm. The live runner displays logs and progress.
+5.  **View the Summary:** When execution finishes, a summary screen appears showing tables of metrics and any hypothesis results collected during the run.
+6.  **Increase Replicates:** Open your `config.yaml`, set `replicates` to `10`, and save.
+7.  **Run Again:** Trigger another `rerun` from the TUI to execute all replicates and view the updated summary.
+
+You've now gone from an idea to a fully executed, reproducible experiment, all managed through the CLI!

--- a/docs/src/content/docs/cli/tutorial-cli-workflow.md
+++ b/docs/src/content/docs/cli/tutorial-cli-workflow.md
@@ -1,50 +1,65 @@
 ---
 title: "Tutorial: Your First CLI Experiment"
-description: A complete walkthrough of creating, configuring, and running an experiment from the command line.
+description: A complete, story-driven walkthrough of creating, configuring, and running an experiment from the command line.
 ---
 
-Welcome! This tutorial will guide you through the recommended workflow for using Crystallize: the interactive Command Line Interface (CLI). We'll build a complete experiment from scratch without writing boilerplate code, letting the TUI do the heavy lifting.
+Welcome! This tutorial is your first step into the world of Crystallize. We'll follow a common story: you have an idea for an experiment and want to see it working as quickly as possible. This guide will show you how to go from zero to a fully functional, running experiment in just a few commands, all from the interactive Command Line Interface (CLI).
 
-### Step 1: Scaffold a New Experiment 🏗️
+## The Goal: A Zero-to-Hero Experiment
 
-First, let's create the file structure for our experiment.
+We're going to use Crystallize's scaffolding power to create a pre-built experiment, run it, and see real results immediately.
 
-1.  Launch the interactive TUI from your terminal:
-    ```bash
-    crystallize
-    ```
-2.  From the main selection screen, press the <kbd>n</kbd> key.
-3.  This opens the **Create New Experiment** screen. Give your experiment a name (e.g., `my-cli-experiment`), ensure the default files are selected, and press the "Create" button.
+### Step 1: Scaffold a New Experiment with Examples
 
-Crystallize will generate a new folder at `experiments/my-cli-experiment/` containing a default `config.yaml` and the necessary Python files (`steps.py`, `datasources.py`, etc.).
+Instead of starting with empty files, we'll tell Crystallize to include example code for us.
 
-### Step 2: Interactive Configuration ✍️
+1. From your terminal, launch the interactive TUI:
+   ```bash
+   crystallize
+   ```
+2. Press the <kbd>n</kbd> key to open the **Create New Experiment** screen.
+3. Enter a name for your experiment, like `hello-crystallize`.
+4. In the **Files to include** list, ensure the defaults (`steps.py`, `datasources.py`) are checked, and also check `verifiers.py`.
+5. Crucially, check the **Add example code** box. This will populate our new files with runnable code.
+6. Click **Create**.
 
-The TUI makes editing your experiment's configuration simple.
+Crystallize has just built a complete, working experiment in `experiments/hello-crystallize/`.
 
-1.  **Select Your Experiment:** The main screen will now show `my-cli-experiment`. As it's highlighted, the right-hand panel displays its configuration in a live tree editor.
-2.  **Add a New Step:** Let's add a new processing step to the pipeline.
-    * Use the arrow keys to navigate the config tree on the right. Go down to `steps`.
-    * Highlight the `+ add step` item and press <kbd>Enter</kbd>.
-    * In the pop-up, enter the name `process_data` and save.
-3.  **The Magic ✨:** When you save, two things happen automatically:
-    * `process_data` is added to the `steps` list in your `config.yaml`.
-    * A placeholder function `def process_data(...):` is scaffolded in `experiments/my-cli-experiment/steps.py`.
+### Step 2: The First Run
 
-This allows you to design your pipeline declaratively. Now, open `steps.py` in your editor and add your logic to the placeholder function.
+Let's run our new experiment without any modifications.
 
-### Step 3: Running the Experiment 📊
+1. Back on the main screen, your `hello-crystallize` experiment is highlighted. Press <kbd>Enter</kbd>.
+2. The **Prepare Run** screen appears. Select `rerun` to execute everything from scratch and press the **Run** button.
+3. The view switches to a live log, showing the experiment running its pipeline for both a baseline and two example treatments.
 
-Once your configuration and step logic are ready, it's time to run.
+### Step 3: The Summary Screen – Instant Results!
 
-1.  **Launch the Run:** In the TUI's left panel, ensure your experiment is highlighted and press <kbd>Enter</kbd>.
-2.  **Choose a Strategy:** The **Prepare Run** screen appears. This is a crucial step where you decide how to execute:
-    * `rerun`: Executes everything from scratch. Use this for final runs or when you know the cache is invalid.
-    * `resume`: Skips any steps that have already been completed successfully with the same inputs. This is perfect for iterating quickly after a failure or when you've only changed a downstream step.
-3.  **Enable Minimal Targets:** For the first run, toggle on only `data_sources` and `steps` in the left panel, leaving the other sections off.
-4.  **Start the Run:** Select the `rerun` option and confirm. The live runner displays logs and progress.
-5.  **View the Summary:** When execution finishes, a summary screen appears showing tables of metrics and any hypothesis results collected during the run.
-6.  **Increase Replicates:** Open your `config.yaml`, set `replicates` to `10`, and save.
-7.  **Run Again:** Trigger another `rerun` from the TUI to execute all replicates and view the updated summary.
+After the run, the **Execution Summary** appears. Because we included example code, the summary is already populated with meaningful results. You'll see two main tables:
 
-You've now gone from an idea to a fully executed, reproducible experiment, all managed through the CLI!
+- **Metrics Table:** Shows the raw metrics collected during the run. The example code calculates a `val` metric, and you can see how its value differs between the baseline, `increase_by_one`, and `increase_by_two` treatments.
+- **Hypothesis Table:** Displays the results of the statistical test defined in the example. It compares each treatment to the baseline and reports a `p_value` and whether the result was significant.
+
+Just by scaffolding and running, you've already got a complete experimental result!
+
+### Step 4: Scaling Up with Replicates
+
+A single run is great, but for statistical confidence we need more replicates.
+
+1. Press <kbd>Esc</kbd> or <kbd>q</kbd> twice to close the summary and return to the main screen.
+2. With `hello-crystallize` highlighted, look at the configuration tree on the right. This is a live editor for your `config.yaml`.
+3. Use the arrow keys to navigate to `replicates`. Press <kbd>e</kbd> to edit, change the value from `1` to `10`, and press <kbd>Enter</kbd> to save.
+
+### Step 5: The Second Run – More Power!
+
+1. Press <kbd>Enter</kbd> on your experiment again.
+2. Choose `rerun`.
+3. The live runner now shows progress for all 10 replicates.
+4. When you reach the **Execution Summary**, you'll see metrics from all 10 runs, giving you a much more robust statistical result for your hypotheses.
+
+Congratulations! You've just seen the full power of the CLI workflow: scaffolding a working experiment, running it, and scaling it up for statistical significance, all in just a few minutes.
+
+## Next Steps
+
+- **Configure Your Experiment:** Learn the details of every field in [`config.yaml`](./how-to-configure.md).
+- **Master the UI:** Dive deeper into the TUI in our [Interactive Management Guide](./how-to-interactive.md).

--- a/docs/src/content/docs/cli/tutorial-cli-workflow.md
+++ b/docs/src/content/docs/cli/tutorial-cli-workflow.md
@@ -30,8 +30,8 @@ Crystallize has just built a complete, working experiment in `experiments/hello-
 Let's run our new experiment without any modifications.
 
 1. Back on the main screen, your `hello-crystallize` experiment is highlighted. Press <kbd>Enter</kbd>.
-2. The **Prepare Run** screen appears. Select `rerun` to execute everything from scratch and press the **Run** button.
-3. The view switches to a live log, showing the experiment running its pipeline for both a baseline and two example treatments.
+2. The **Prepare Run** screen appears. Make sure only **datasource** and **steps** are enabled and select `rerun` to execute everything from scratch.
+3. Press **Run** to start. The view switches to a live log, showing the pipeline for both the baseline and two example treatments.
 
 ### Step 3: The Summary Screen – Instant Results!
 
@@ -62,4 +62,4 @@ Congratulations! You've just seen the full power of the CLI workflow: scaffoldin
 ## Next Steps
 
 - **Configure Your Experiment:** Learn the details of every field in [`config.yaml`](./how-to-configure.md).
-- **Master the UI:** Dive deeper into the TUI in our [Interactive Management Guide](./how-to-interactive.md).
+- **Chain Experiments:** Build on this tutorial in [Putting It All Together - Building a Graph Experiment](./tutorial-graph-experiment.md).

--- a/docs/src/content/docs/cli/tutorial-graph-experiment.md
+++ b/docs/src/content/docs/cli/tutorial-graph-experiment.md
@@ -1,0 +1,99 @@
+---
+title: "Putting It All Together - Building a Graph Experiment"
+description: A guided walkthrough for constructing a small graph of experiments and consuming their outputs.
+---
+
+This tutorial walks through creating a three-experiment graph that demonstrates how Crystallize chains experiments together. We'll create two simple "producer" experiments and a "consumer" experiment that uses their outputs.
+
+## The Goal: Calculate a Comfort Index
+We'll combine temperature and humidity analyses, then test whether a scaling factor significantly changes the temperature average.
+
+### Step 1: Create the `temperature-stats` Experiment
+1. In the TUI, press <kbd>n</kbd> to create a new experiment named `temperature-stats`.
+2. Ensure `datasources.py`, `steps.py`, `outputs.py`, and `verifiers.py` are included.
+3. In the config editor:
+   - Under **outputs** add an output with alias `avg_temp_out` and file name `temp.json`.
+   - Under **steps** add a step named `average_temp`.
+   - Under **treatments** add a `baseline` treatment with `factor: 1.0` and another treatment `scaled_up` with `factor: 1.5`.
+   - Under **hypotheses** add a hypothesis `check_scaling_effect` that uses the `t_test` verifier and checks the `average_temp` metric.
+   - Set `replicates` to `30`.
+4. Implement the logic in the generated Python files.
+
+`experiments/temperature-stats/datasources.py`
+```python
+from crystallize import data_source
+import random
+
+@data_source
+def temperatures(ctx):
+    all_temps = [72, 75, 71, 73, 76, 74, 70]
+    return random.sample(all_temps, 2)
+```
+
+`experiments/temperature-stats/steps.py`
+```python
+from crystallize import pipeline_step, Artifact
+import json
+
+@pipeline_step()
+def average_temp(data, *, avg_temp_out: Artifact, factor: float = 1.0):
+    avg = (sum(data) / len(data)) * factor
+    avg_temp_out.write(json.dumps({"average": avg}).encode())
+    return data, {"average_temp": avg}
+```
+
+`experiments/temperature-stats/verifiers.py`
+```python
+from crystallize import verifier
+from scipy.stats import ttest_ind
+
+@verifier
+def t_test(baseline_samples, treatment_samples):
+    stat, p = ttest_ind(
+        treatment_samples["average_temp"],
+        baseline_samples["average_temp"],
+        equal_var=False,
+    )
+    return {"p_value": p, "significant": p < 0.05}
+```
+
+Update `config.yaml` to use the new datasource function:
+```yaml
+datasource:
+  temps: temperatures
+```
+
+### Step 2: Create the `humidity-stats` Experiment
+1. Repeat the process for a new experiment named `humidity-stats`.
+2. Include `outputs.py` and create an output `avg_humidity_out` with file name `humidity.json`.
+3. Add a step `average_humidity` and set `replicates` to `1`.
+4. Implement the step logic to compute a simple average using data such as `[0.45, 0.50, 0.55]`.
+
+### Step 3: Create the `comfort-index` Experiment
+1. Press <kbd>n</kbd> to create a new experiment named `comfort-index` and set `replicates` to `30`.
+2. Check **Use outputs from other experiments** and select `avg_temp_out` from `temperature-stats` and `avg_humidity_out` from `humidity-stats`.
+3. Add a final step named `calculate_comfort_index`.
+4. Implement the step logic:
+
+`experiments/comfort-index/steps.py`
+```python
+from crystallize import pipeline_step
+import json
+
+@pipeline_step()
+def calculate_comfort_index(data: dict):
+    with open(data["avg_temp_out"]) as f:
+        temp = json.load(f)["average"]
+    with open(data["avg_humidity_out"]) as f:
+        humidity = json.load(f)["average"]
+    comfort = temp - (humidity * 10)
+    return data, {"comfort_index": comfort}
+```
+
+### Step 4: Run the Graph
+When you run `comfort-index` in the TUI, Crystallize automatically executes its dependencies:
+- `temperature-stats` runs for 30 replicates for both treatments.
+- `humidity-stats` runs once.
+- `comfort-index` runs 30 times, consuming the produced artifacts.
+
+The summary shows metrics and hypothesis results for all experiments, demonstrating how graphs let you orchestrate complex workflows.

--- a/docs/src/content/docs/cli/tutorial-graph-experiment.md
+++ b/docs/src/content/docs/cli/tutorial-graph-experiment.md
@@ -1,16 +1,18 @@
 ---
-title: "Putting It All Together - Building a Graph Experiment"
+title: 'Putting It All Together - Building a Graph Experiment'
 description: A guided walkthrough for constructing a small graph of experiments and consuming their outputs.
 ---
 
 This tutorial walks through creating a three-experiment graph that demonstrates how Crystallize chains experiments together. We'll create two simple "producer" experiments and a "consumer" experiment that uses their outputs.
 
 ## The Goal: Calculate a Comfort Index
+
 We'll combine temperature and humidity analyses, then test whether a scaling factor significantly changes the temperature average.
 
 ### Step 1: Create the `temperature-stats` Experiment
+
 1. In the TUI, press <kbd>n</kbd> to create a new experiment named `temperature-stats`.
-2. Ensure `datasources.py`, `steps.py`, `outputs.py`, and `verifiers.py` are included.
+2. Ensure `datasources.py`, `steps.py`, `outputs.py`, and `verifiers.py` are included. Don't include the example files, then click `Create`.
 3. In the config editor:
    - Under **outputs** add an output with alias `avg_temp_out` and file name `temp.json`.
    - Under **steps** add a step named `average_temp`.
@@ -20,29 +22,38 @@ We'll combine temperature and humidity analyses, then test whether a scaling fac
 4. Implement the logic in the generated Python files.
 
 `experiments/temperature-stats/datasources.py`
+
 ```python
 from crystallize import data_source
 import random
 
 @data_source
 def temperatures(ctx):
+    # Sample 2 random temperatures to introduce variability.
+    # This is safe because Crystallize's SeedPlugin ensures that the random
+    # seed is the same for the same replicate number across different
+    # treatments, but different for each new replicate.
     all_temps = [72, 75, 71, 73, 76, 74, 70]
     return random.sample(all_temps, 2)
 ```
 
 `experiments/temperature-stats/steps.py`
+
 ```python
 from crystallize import pipeline_step, Artifact
 import json
 
 @pipeline_step()
 def average_temp(data, *, avg_temp_out: Artifact, factor: float = 1.0):
+    # The `factor` is injected by the treatment
     avg = (sum(data) / len(data)) * factor
     avg_temp_out.write(json.dumps({"average": avg}).encode())
+    # Return the data and the metric for the hypothesis
     return data, {"average_temp": avg}
 ```
 
 `experiments/temperature-stats/verifiers.py`
+
 ```python
 from crystallize import verifier
 from scipy.stats import ttest_ind
@@ -58,24 +69,28 @@ def t_test(baseline_samples, treatment_samples):
 ```
 
 Update `config.yaml` to use the new datasource function:
+
 ```yaml
 datasource:
   temps: temperatures
 ```
 
 ### Step 2: Create the `humidity-stats` Experiment
+
 1. Repeat the process for a new experiment named `humidity-stats`.
 2. Include `outputs.py` and create an output `avg_humidity_out` with file name `humidity.json`.
 3. Add a step `average_humidity` and set `replicates` to `1`.
 4. Implement the step logic to compute a simple average using data such as `[0.45, 0.50, 0.55]`.
 
 ### Step 3: Create the `comfort-index` Experiment
+
 1. Press <kbd>n</kbd> to create a new experiment named `comfort-index` and set `replicates` to `30`.
 2. Check **Use outputs from other experiments** and select `avg_temp_out` from `temperature-stats` and `avg_humidity_out` from `humidity-stats`.
 3. Add a final step named `calculate_comfort_index`.
 4. Implement the step logic:
 
 `experiments/comfort-index/steps.py`
+
 ```python
 from crystallize import pipeline_step
 import json
@@ -91,7 +106,9 @@ def calculate_comfort_index(data: dict):
 ```
 
 ### Step 4: Run the Graph
+
 When you run `comfort-index` in the TUI, Crystallize automatically executes its dependencies:
+
 - `temperature-stats` runs for 30 replicates for both treatments.
 - `humidity-stats` runs once.
 - `comfort-index` runs 30 times, consuming the produced artifacts.


### PR DESCRIPTION
### Summary
Adds first tutorial for using the Crystallize CLI and links it in the docs sidebar.

### Changes
- sidebar section for CLI documentation
- tutorial on creating, configuring and running an experiment from the CLI

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_68873ee52bf483298da9470fce565488