### PR TITLE
Fix artifact writer logic

### DIFF
--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -374,3 +374,12 @@ def test_lambda_loader_pickleable(tmp_path):
     dumped = pickle.dumps(loader_art)
     clone = pickle.loads(dumped)
     assert clone.loader(path) == "hello"
+
+
+def test_default_writer(tmp_path):
+    from crystallize.datasources.artifacts import default_writer
+
+    assert default_writer(b"x") == b"x"
+    assert default_writer("x") == b"x"
+    with pytest.raises(TypeError):
+        default_writer(1)  # type: ignore[arg-type]


### PR DESCRIPTION
### Summary
- ensure `Artifact` writer returns byte data
- generalize picklable callable wrapper
- add unit tests for new default writer behaviour

### Changes
- update writer implementation in `Artifact`
- implement `_PickleableCallable` utility
- add new tests covering `default_writer`

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_688934a1b4bc8329a4de7f7d6d14704e