### PR TITLE
Implement treatment inheritance in experiment graphs

### DIFF
--- a/crystallize/datasources/artifacts.py
+++ b/crystallize/datasources/artifacts.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 import json
 from pathlib import Path
 from typing import Any, Callable, List, Optional, TYPE_CHECKING
-import pickle
 import dill
 
 from crystallize.utils.exceptions import ContextMutationError

--- a/crystallize/experiments/experiment_graph.py
+++ b/crystallize/experiments/experiment_graph.py
@@ -26,6 +26,7 @@ class ExperimentGraph:
         """Create a graph and optionally infer dependencies from experiments."""
         self._graph = nx.DiGraph()
         self._results: Dict[str, Result] = {}
+        self._treatment_cache: Dict[str, list[Treatment]] = {}
         self.name = name
 
         if experiments:
@@ -240,6 +241,38 @@ class ExperimentGraph:
 
     # ------------------------------------------------------------------ #
 
+    def _get_parents(self, name: str) -> list[str]:
+        if hasattr(self._graph, "predecessors"):
+            return list(self._graph.predecessors(name))
+        # pragma: no cover - fallback for minimal networkx stub
+        return [n for n, succ in getattr(self._graph, "_succ", {}).items() if name in succ]
+
+    def _get_treatments_for_experiment(
+        self, name: str, global_treatments: list[Treatment] | None
+    ) -> list[Treatment]:
+        """Return the treatments for ``name`` after applying inheritance."""
+
+        if global_treatments is not None:
+            return global_treatments
+
+        if name in self._treatment_cache:
+            return self._treatment_cache[name]
+
+        exp: Experiment = self._graph.nodes[name]["experiment"]
+
+        parent_treatments: dict[str, Treatment] = {}
+        for parent_name in self._get_parents(name):
+            for t in self._get_treatments_for_experiment(parent_name, None):
+                parent_treatments[t.name] = t
+
+        own_treatments: dict[str, Treatment] = {t.name: t for t in exp.treatments}
+
+        merged: dict[str, Treatment] = {**parent_treatments, **own_treatments}
+        self._treatment_cache[name] = list(merged.values())
+        return self._treatment_cache[name]
+
+    # ------------------------------------------------------------------ #
+
     def run(
         self,
         treatments: List[Treatment] | None = None,
@@ -266,27 +299,22 @@ class ExperimentGraph:
 
         order = list(nx.topological_sort(self._graph))
         self._results.clear()
+        self._treatment_cache.clear()
 
         for name in order:
             exp: Experiment = self._graph.nodes[name]["experiment"]
             run_strategy = strategy
+
+            final_treatments_for_exp = self._get_treatments_for_experiment(
+                name, treatments
+            )
 
             if strategy == "resume":
                 plugin = exp.get_plugin(ArtifactPlugin)
                 if plugin is not None:
                     base = Path(plugin.root_dir) / (exp.name or exp.id) / "v0"
 
-                    run_treatments = treatments or []
-                    exp_treatments_on_obj = getattr(exp, "treatments", [])
-                    if exp_treatments_on_obj:
-                        existing_names = {t.name for t in run_treatments}
-                        run_treatments.extend(
-                            [
-                                t
-                                for t in exp_treatments_on_obj
-                                if t.name not in existing_names
-                            ]
-                        )
+                    run_treatments = final_treatments_for_exp
 
                     conditions_to_check = [BASELINE_CONDITION] + [
                         t.name for t in run_treatments
@@ -355,10 +383,6 @@ class ExperimentGraph:
 
             if progress_callback:
                 await progress_callback("running", name)
-
-            final_treatments_for_exp = (
-                treatments if treatments is not None else getattr(exp, "treatments", [])
-            )
 
             result = await exp.arun(
                 treatments=final_treatments_for_exp,

--- a/docs/src/content/docs/reference/experiment_graph.md
+++ b/docs/src/content/docs/reference/experiment_graph.md
@@ -70,6 +70,10 @@ run(
 ) → Dict[str, Result]
 ```
 
-Execute all experiments respecting dependency order. 
+Execute all experiments respecting dependency order.
+
+Treatments declared on an experiment are inherited by all downstream
+experiments. The ``treatments`` argument overrides this automatic
+propagation with a custom list for the entire graph.
 
 

--- a/tests/test_experiment_graph_treatments.py
+++ b/tests/test_experiment_graph_treatments.py
@@ -1,0 +1,107 @@
+from crystallize.datasources.datasource import DataSource
+from crystallize.experiments.experiment import Experiment
+from crystallize.experiments.experiment_graph import ExperimentGraph
+from crystallize.experiments.treatment import Treatment
+from crystallize.pipelines.pipeline import Pipeline
+from crystallize.pipelines.pipeline_step import PipelineStep
+from crystallize.utils.context import FrozenContext
+
+
+class DummySource(DataSource):
+    def fetch(self, ctx: FrozenContext):
+        return ctx.get("replicate", 0)
+
+
+class PassStep(PipelineStep):
+    def __call__(self, data, ctx):
+        ctx.metrics.add("val", data + ctx.get("increment", 0))
+        return data
+
+    @property
+    def params(self):
+        return {}
+
+
+def build_experiment(name: str, treatments=None) -> Experiment:
+    exp = Experiment(
+        datasource=DummySource(),
+        pipeline=Pipeline([PassStep()]),
+        name=name,
+        treatments=treatments or [],
+    )
+    exp.validate()
+    return exp
+
+
+def test_treatment_inheritance_linear():
+    t = Treatment("inc", {"increment": 1})
+    exp1 = build_experiment("a", [t])
+    exp2 = build_experiment("b")
+    exp3 = build_experiment("c")
+
+    graph = ExperimentGraph()
+    for exp in (exp1, exp2, exp3):
+        graph.add_experiment(exp)
+    graph.add_dependency(exp2, exp1)
+    graph.add_dependency(exp3, exp2)
+
+    results = graph.run()
+
+    assert "inc" in results["b"].metrics.treatments
+    assert "inc" in results["c"].metrics.treatments
+
+
+def test_treatment_inheritance_merge_same():
+    t = Treatment("inc", {"increment": 1})
+    exp_a = build_experiment("a", [t])
+    exp_b = build_experiment("b", [t])
+    exp_c = build_experiment("c")
+
+    graph = ExperimentGraph()
+    for exp in (exp_a, exp_b, exp_c):
+        graph.add_experiment(exp)
+    graph.add_dependency(exp_c, exp_a)
+    graph.add_dependency(exp_c, exp_b)
+
+    results = graph.run()
+
+    assert set(results["c"].metrics.treatments) == {"inc"}
+
+
+def test_treatment_inheritance_merge_different():
+    t1 = Treatment("inc_a", {"increment": 1})
+    t2 = Treatment("inc_b", {"increment": 2})
+    exp_a = build_experiment("a", [t1])
+    exp_b = build_experiment("b", [t2])
+    exp_c = build_experiment("c")
+
+    graph = ExperimentGraph()
+    for exp in (exp_a, exp_b, exp_c):
+        graph.add_experiment(exp)
+    graph.add_dependency(exp_c, exp_a)
+    graph.add_dependency(exp_c, exp_b)
+
+    results = graph.run()
+
+    assert set(results["c"].metrics.treatments) == {"inc_a", "inc_b"}
+
+
+def test_treatment_propagation_from_middle():
+    t = Treatment("mid", {"increment": 1})
+    exp1 = build_experiment("one")
+    exp2 = build_experiment("two", [t])
+    exp3 = build_experiment("three")
+    exp4 = build_experiment("four")
+
+    graph = ExperimentGraph()
+    for exp in (exp1, exp2, exp3, exp4):
+        graph.add_experiment(exp)
+    graph.add_dependency(exp2, exp1)
+    graph.add_dependency(exp3, exp2)
+    graph.add_dependency(exp4, exp3)
+
+    results = graph.run()
+
+    assert "mid" in results["three"].metrics.treatments
+    assert "mid" in results["four"].metrics.treatments
+


### PR DESCRIPTION
### Summary
- improve handling of treatments across experiment graphs
- add helper `_get_treatments_for_experiment`
- handle minimal networkx stub used in tests
- remove unused `pickle` import
- add tests for treatment inheritance
- document inheritance behavior

### Changes
- new helper computes inherited/overridden treatments and caches results
- `arun` now uses the helper and resets cache per run
- new tests validate linear and merged inheritance scenarios
- reference docs mention treatment propagation

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_68896fa4e1a883298699d299f3937995