### PR TITLE
Add cyclical experiment loops

### DIFF
--- a/cli/screens/run.py
+++ b/cli/screens/run.py
@@ -23,6 +23,7 @@ from textual.widgets import Button, Footer, Header, RichLog, Static, TextArea
 
 from crystallize.experiments.experiment import Experiment
 from crystallize.experiments.experiment_graph import ExperimentGraph
+from crystallize.loops.experiment_loop import ExperimentLoop
 from crystallize.plugins.plugins import ArtifactPlugin
 from ..status_plugin import CLIStatusPlugin
 from ..discovery import _run_object
@@ -338,9 +339,14 @@ async def _launch_run(app: App, obj: Any) -> None:
     selected = obj
     deletable: List[Tuple[str, Path]] = []
 
-    if isinstance(selected, ExperimentGraph):
-        for node in selected._graph.nodes:
-            exp: Experiment = selected._graph.nodes[node]["experiment"]
+    if isinstance(selected, ExperimentLoop):
+        graph = selected.graph
+    else:
+        graph = selected if isinstance(selected, ExperimentGraph) else None
+
+    if graph is not None:
+        for node in graph._graph.nodes:
+            exp: Experiment = graph._graph.nodes[node]["experiment"]
             plugin = exp.get_plugin(ArtifactPlugin)
             if not plugin or not exp.name:
                 continue

--- a/crystallize/__init__.py
+++ b/crystallize/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from crystallize.experiments.experiment_graph import ExperimentGraph
 from crystallize.experiments.experiment import Experiment
+from crystallize.loops.experiment_loop import ExperimentLoop
 from crystallize.experiments.experiment_builder import ExperimentBuilder
 from crystallize.datasources.datasource import DataSource, ExperimentInput
 from crystallize.datasources import Artifact
@@ -59,6 +60,7 @@ __all__ = [
     "LoggingPlugin",
     "ArtifactPlugin",
     "ExperimentGraph",
+    "ExperimentLoop",
     "Artifact",
     "ExperimentInput",
     "ExperimentBuilder",

--- a/crystallize/loops/experiment_loop.py
+++ b/crystallize/loops/experiment_loop.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import importlib.util
+import operator
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict, List
+
+import yaml
+
+from crystallize.experiments.experiment_graph import ExperimentGraph
+from crystallize.plugins.plugins import ArtifactPlugin
+from crystallize.utils.context import FrozenContext
+from crystallize.utils.constants import BASELINE_CONDITION
+
+
+OP_MAP = {
+    ">": operator.gt,
+    ">=": operator.ge,
+    "<": operator.lt,
+    "<=": operator.le,
+    "==": operator.eq,
+    "!=": operator.ne,
+}
+
+
+@dataclass
+class ConvergenceCondition:
+    experiment: str
+    metric: str
+    condition: str
+    operator: str
+    threshold: float
+    patience: int = 1
+
+
+@dataclass
+class MutationSpec:
+    experiment: str
+    treatment: str
+    replace_context_key: str
+    from_artifact: str
+    loader: str
+
+
+class ExperimentLoop:
+    """Run a DAG of experiments iteratively with mutation between runs."""
+
+    def __init__(
+        self,
+        graph: ExperimentGraph,
+        eval_experiment: str,
+        max_iters: int,
+        converge_when: List[ConvergenceCondition],
+        mutate: List[MutationSpec],
+        loader_module: ModuleType,
+    ) -> None:
+        self.graph = graph
+        self.eval_experiment = eval_experiment
+        self.max_iters = max_iters
+        self.converge_when = converge_when
+        self.mutate = mutate
+        self.loader_module = loader_module
+        self._patience: Dict[int, int] = {id(c): 0 for c in converge_when}
+
+    @classmethod
+    def from_yaml(
+        cls, config_path: str | Path
+    ) -> "ExperimentLoop":  # pragma: no cover - convenience loader
+        path = Path(config_path)
+        with open(path) as f:
+            cfg = yaml.safe_load(f) or {}
+        base = path.parent
+        eval_exp = cfg["eval_experiment"]
+        graph = ExperimentGraph.from_yaml(base / eval_exp / "config.yaml")
+        conditions = [
+            ConvergenceCondition(
+                experiment=c["experiment"],
+                metric=c["metric"],
+                condition=c.get("condition", BASELINE_CONDITION),
+                operator=c["operator"],
+                threshold=float(c["threshold"]),
+                patience=int(c.get("patience", 1)),
+            )
+            for c in cfg.get("converge_when", [])
+        ]
+        mutations = [
+            MutationSpec(
+                experiment=m["experiment"],
+                treatment=m["treatment"],
+                replace_context_key=m["replace_context_key"],
+                from_artifact=m["from_artifact"],
+                loader=m["loader"],
+            )
+            for m in cfg.get("mutate", [])
+        ]
+        loader_mod = cls._load_loader_module(base)
+        max_iters = int(cfg.get("max_iters", 1))
+        return cls(graph, eval_exp, max_iters, conditions, mutations, loader_mod)
+
+    @staticmethod
+    def _load_loader_module(
+        base: Path,
+    ) -> ModuleType:  # pragma: no cover - convenience loader
+        mod_path = base / "loaders.py"
+        spec = importlib.util.spec_from_file_location("loop_loaders", mod_path)
+        module = ModuleType("loop_loaders")
+        if spec and spec.loader and mod_path.exists():
+            spec.loader.exec_module(module)  # type: ignore[arg-type]
+        return module
+
+    def _set_versions(self, iteration: int) -> None:
+        for node in self.graph._graph.nodes:
+            exp = self.graph._graph.nodes[node]["experiment"]
+            plugin = exp.get_plugin(ArtifactPlugin)
+            if plugin is not None:
+                plugin.versioned = True
+                plugin.version_override = iteration
+
+    def _apply_mutations(self, iteration: int) -> None:
+        for m in self.mutate:
+            src_exp_name, art_name = m.from_artifact.split("#", 1)
+            src_exp = self.graph._graph.nodes[src_exp_name]["experiment"]
+            src_plugin = src_exp.get_plugin(ArtifactPlugin)
+            if src_plugin is None:
+                continue
+            base = (
+                Path(src_plugin.root_dir)
+                / (src_exp.name or src_exp.id)
+                / f"v{iteration}"
+            )
+            matches = list(base.rglob(art_name))
+            if not matches:
+                continue
+            art_path = matches[0]
+            loader_fn = getattr(self.loader_module, m.loader)
+            new_val = loader_fn(art_path)
+            tgt_exp = self.graph._graph.nodes[m.experiment]["experiment"]
+            if m.treatment == BASELINE_CONDITION:
+                data = dict(tgt_exp._setup_ctx.as_dict())
+                data[m.replace_context_key] = new_val
+                tgt_exp._setup_ctx = FrozenContext(data)
+            else:
+                for t in tgt_exp.treatments:
+                    if t.name == m.treatment and hasattr(t._apply_fn, "items"):
+                        t._apply_fn.items[m.replace_context_key] = new_val
+                        break
+
+    def _check_convergence(self, results: Dict[str, Any]) -> bool:
+        all_met = True
+        for cond in self.converge_when:
+            res = results.get(cond.experiment)
+            if res is None:
+                all_met = False
+                continue
+            metrics = res.metrics
+            if cond.condition == BASELINE_CONDITION:
+                vals = metrics.baseline.metrics.get(cond.metric, [])
+            else:
+                vals = metrics.treatments.get(cond.condition, {}).metrics.get(
+                    cond.metric, []
+                )
+            if not vals:
+                met = False
+            else:
+                val = vals[-1]
+                op_fn = OP_MAP.get(cond.operator, operator.eq)
+                met = op_fn(val, cond.threshold)
+            key = id(cond)
+            if met:
+                self._patience[key] += 1
+            else:
+                self._patience[key] = 0
+                all_met = False
+                continue
+            if self._patience[key] < cond.patience:
+                all_met = False
+        return all_met
+
+    async def arun(self) -> Dict[str, Any]:
+        iteration = 0
+        results: Dict[str, Any] = {}
+        while iteration < self.max_iters:
+            self._set_versions(iteration)
+            results = await self.graph.arun(strategy="rerun")
+            if self._check_convergence(results):
+                break
+            if iteration + 1 >= self.max_iters:
+                break
+            self._apply_mutations(iteration)
+            iteration += 1
+        return results

--- a/crystallize/plugins/plugins.py
+++ b/crystallize/plugins/plugins.py
@@ -191,12 +191,15 @@ class ArtifactPlugin(BasePlugin):
         base = Path(self.root_dir) / self.experiment_id
         base.mkdir(parents=True, exist_ok=True)
         if self.versioned:
-            versions = [
-                int(p.name[1:])
-                for p in base.glob("v*")
-                if p.name.startswith("v") and p.name[1:].isdigit()
-            ]
-            self.version = max(versions, default=-1) + 1
+            if hasattr(self, "version_override"):
+                self.version = self.version_override
+            else:
+                versions = [
+                    int(p.name[1:])
+                    for p in base.glob("v*")
+                    if p.name.startswith("v") and p.name[1:].isdigit()
+                ]
+                self.version = max(versions, default=-1) + 1
         else:
             self.version = 0
         self._manifest.clear()
@@ -243,6 +246,7 @@ class ArtifactPlugin(BasePlugin):
         def dump_condition(name: str, metrics: Mapping[str, Any]) -> None:
             dest = base / name
             os.makedirs(dest, exist_ok=True)
+
             def _default(o: Any) -> Any:
                 try:
                     import numpy as np
@@ -268,3 +272,5 @@ class ArtifactPlugin(BasePlugin):
         with open(base / "_manifest.json", "w") as f:
             json.dump(self._manifest, f)
         self._manifest.clear()
+        if hasattr(self, "version_override"):
+            delattr(self, "version_override")

--- a/tests/test_cli_yaml_discovery.py
+++ b/tests/test_cli_yaml_discovery.py
@@ -31,7 +31,7 @@ def test_yaml_discovery(tmp_path: Path) -> None:
     cfg3 = {"name": "other", "datasource": {"n": "numbers"}}
     (other / "config.yaml").write_text(yaml.safe_dump(cfg3))
 
-    graphs, experiments, errors = discover_configs(tmp_path)
+    loops, graphs, experiments, errors = discover_configs(tmp_path)
 
     graph_paths = {info["path"] for info in graphs.values()}
     exp_paths = {info["path"] for info in experiments.values()}


### PR DESCRIPTION
### Summary
Implemented cyclical experiment loops with new `loop_config.yaml` discovery and runner.
Added `ExperimentLoop` for iterative DAG execution with mutation and convergence logic. CLI updated to detect and run loops. New tests cover loop iteration and artifact versioning.

### Changes
- Added `ExperimentLoop` module with mutation and convergence handling
- Updated CLI discovery and UI to show loops
- Added loop support to run screen
- Modified `ArtifactPlugin` to allow version overrides
- Added tests for loop discovery and basic loop execution

### Testing & Verification
- `pixi run lint`
- `pixi run test`
- `pixi run cov`
- `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_688b023885dc8329ae65dac0a8c84759