### PR TITLE
fix: textual now has a TextualLoggingPlugin that allows the user to d…

### DIFF
--- a/crystallize/experiments/experiment.py
+++ b/crystallize/experiments/experiment.py
@@ -797,6 +797,8 @@ class Experiment:
                     data = self.datasource.fetch(ctx)
 
                 for step in self.pipeline.steps:
+                    for plugin in self.plugins:
+                        plugin.before_step(self, step)
                     data = step(data, ctx)
                     for plugin in self.plugins:
                         plugin.after_step(self, step, data, ctx)

--- a/crystallize/pipelines/pipeline.py
+++ b/crystallize/pipelines/pipeline.py
@@ -81,6 +81,10 @@ class Pipeline:
 
             input_hash = compute_hash(data)
 
+            if experiment is not None:
+                for plugin in experiment.plugins:
+                    plugin.before_step(experiment, step)
+
             if step.cacheable:
                 try:
                     result = load_cache(step_hash, input_hash)

--- a/crystallize/plugins/plugins.py
+++ b/crystallize/plugins/plugins.py
@@ -62,6 +62,9 @@ class BasePlugin(ABC):
         """Observe results after every :class:`PipelineStep` execution."""
         pass
 
+    def before_step(self, experiment: Experiment, step: PipelineStep) -> None:
+        pass
+
     def after_run(self, experiment: Experiment, result: Result) -> None:
         """Execute cleanup or reporting after :meth:`Experiment.run` completes."""
         pass
@@ -243,6 +246,7 @@ class ArtifactPlugin(BasePlugin):
         def dump_condition(name: str, metrics: Mapping[str, Any]) -> None:
             dest = base / name
             os.makedirs(dest, exist_ok=True)
+
             def _default(o: Any) -> Any:
                 try:
                     import numpy as np

--- a/tests/test_cli_status_plugin.py
+++ b/tests/test_cli_status_plugin.py
@@ -32,7 +32,7 @@ def step_b(data, ctx):
 
 def test_cli_status_plugin_progress():
     events.clear()
-    plugin = CLIStatusPlugin(record, log=logging.getLogger("test"))
+    plugin = CLIStatusPlugin(record)
     treatment = Treatment("t", {})
     exp = Experiment(
         datasource=ds(),
@@ -56,22 +56,22 @@ def test_cli_status_plugin_progress():
 
 
 def test_inject_status_plugin_deduplicates_experiment():
-    plugin = CLIStatusPlugin(lambda e, i: None, log=logging.getLogger("test"))
+    plugin = CLIStatusPlugin(lambda e, i: None)
     exp = Experiment(datasource=ds(), pipeline=Pipeline([step_a()]), plugins=[plugin])
     exp.validate()
-    _inject_status_plugin(exp, lambda e, i: None, log=logging.getLogger("test"))
+    _inject_status_plugin(exp, lambda e, i: None, writer=None)
     count = sum(isinstance(p, CLIStatusPlugin) for p in exp.plugins)
     assert count == 1
 
 
 def test_inject_status_plugin_deduplicates_graph():
-    plugin = CLIStatusPlugin(lambda e, i: None, log=logging.getLogger("test"))
+    plugin = CLIStatusPlugin(lambda e, i: None)
     exp = Experiment(
         datasource=ds(), pipeline=Pipeline([step_a()]), plugins=[plugin], name="e"
     )
     exp.validate()
     graph = ExperimentGraph.from_experiments([exp])
-    _inject_status_plugin(graph, lambda e, i: None, log=logging.getLogger("test"))
+    _inject_status_plugin(graph, lambda e, i: None, writer=None)
     exp2 = graph._graph.nodes["e"]["experiment"]
     count = sum(isinstance(p, CLIStatusPlugin) for p in exp2.plugins)
     assert count == 1


### PR DESCRIPTION
## 📖 Summary of Documentation Changes

Textual steps can now use ctx.logger to call the root logger and that will go to the runner screen. This makes the user experience easier to use.

## ✏️ Changes

- Added TextualLoggingPlugin
- Added before_step for plugins

## ✅ Testing & Verification

- [x] Reviewed changes locally
- [x] Verified links and references
- [ ] Requested review from relevant stakeholders (optional)
