### PR TITLE
fix(cli): clarify experiment load errors

### DIFF
--- a/cli/discovery.py
+++ b/cli/discovery.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Optional, Tuple, Type
 import yaml
 
 from crystallize.experiments.experiment_graph import ExperimentGraph
+from .errors import ExperimentLoadError, format_load_error
 
 
 def _import_module(
@@ -82,7 +83,7 @@ def discover_configs(
 ) -> Tuple[
     Dict[str, Dict[str, Any]],
     Dict[str, Dict[str, Any]],
-    Dict[str, BaseException],
+    Dict[str, ExperimentLoadError],
 ]:
     """Discover experiments and graphs defined via ``config.yaml``."""
 
@@ -97,7 +98,7 @@ def discover_configs(
 
     graphs: Dict[str, Dict[str, Any]] = {}
     experiments: Dict[str, Dict[str, Any]] = {}
-    errors: Dict[str, BaseException] = {}
+    errors: Dict[str, ExperimentLoadError] = {}
 
     abs_directory = directory.resolve()
     cwd = Path.cwd()
@@ -144,7 +145,7 @@ def discover_configs(
             else:
                 experiments[label] = info
         except BaseException as exc:  # noqa: BLE001
-            errors[str(cfg)] = exc
+            errors[str(cfg)] = format_load_error(cfg, exc)
 
     return graphs, experiments, errors
 

--- a/cli/errors.py
+++ b/cli/errors.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+class ExperimentLoadError(Exception):
+    """Raised when an experiment fails to load."""
+
+
+def format_load_error(path: Path, error: BaseException) -> ExperimentLoadError:
+    """Return a user-facing error for an experiment load failure.
+
+    Args:
+        path: Path to the experiment's ``config.yaml``.
+        error: Original exception raised during loading.
+    """
+    if isinstance(error, yaml.YAMLError):
+        msg = f"Invalid YAML in {path}: {error}"
+    elif isinstance(error, FileNotFoundError):
+        missing = error.filename or str(error)
+        msg = f"File '{missing}' referenced in {path} was not found."
+    elif isinstance(error, AttributeError):
+        msg = (
+            f"{path}: {error}. Verify your configuration references valid modules and attributes."
+        )
+    elif isinstance(error, KeyError):
+        msg = f"Missing required configuration key {error} in {path}."
+    else:
+        msg = f"{path}: {error}"
+    return ExperimentLoadError(msg)

--- a/cli/screens/load_error.py
+++ b/cli/screens/load_error.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-from typing import Dict
-
 from textual.app import ComposeResult
 from textual.containers import Container
-from textual.widgets import Button, Static, Tree
 from textual.screen import ModalScreen
+from textual.widgets import Button, Static
 
 
-class LoadErrorsScreen(ModalScreen[None]):
-    """Display import errors found during discovery."""
+class LoadErrorScreen(ModalScreen[None]):
+    """Modal screen displaying a single load error."""
 
     BINDINGS = [
         ("ctrl+c", "close", "Close"),
@@ -17,18 +15,14 @@ class LoadErrorsScreen(ModalScreen[None]):
         ("q", "close", "Close"),
     ]
 
-    def __init__(self, errors: Dict[str, BaseException]) -> None:
+    def __init__(self, message: str) -> None:
         super().__init__()
-        self._errors = errors
+        self._message = message
 
     def compose(self) -> ComposeResult:
         with Container():
-            yield Static("Load Errors", id="modal-title")
-            tree = Tree("Failed to load files")
-            for file, err in self._errors.items():
-                node = tree.root.add(str(file))
-                node.add(str(err))
-            yield tree
+            yield Static("Load Error", id="modal-title")
+            yield Static(self._message, id="error-msg")
             yield Button("Close", id="close")
 
     def on_button_pressed(self, event: Button.Pressed) -> None:

--- a/cli/widgets/config_editor.py
+++ b/cli/widgets/config_editor.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-import yaml
 from pathlib import Path
 from typing import Any, Dict, List
+
+import yaml
 
 from ..utils import add_placeholder
 
@@ -223,9 +224,7 @@ class ConfigEditorWidget(Container):
 
     async def action_edit(self) -> None:
         node = self.cfg_tree.cursor_node
-        if node.parent.is_root:
-            return
-        if node is None or node.data is None:
+        if node is None or node.data is None or node.parent is None or node.parent.is_root:
             return
 
         def _edit_sync(result: str | None) -> None:
@@ -366,7 +365,7 @@ class ConfigEditorWidget(Container):
                         value = int(value)
                 except ValueError:
                     value = result["value"]
-                tr[result["name"]] = {result["context_field"]: result["value"]}
+                tr[result["name"]] = {result["context_field"]: value}
             self.cfg_tree.root.remove_children()
             self.cfg_tree._build_tree(self.cfg_tree.root, self._data, [])
             self.cfg_tree.focus()

--- a/tests/test_run_screen.py
+++ b/tests/test_run_screen.py
@@ -1,11 +1,17 @@
+from __future__ import annotations
+
 from pathlib import Path
+from typing import Any
 
 import importlib
 import sys
 import time
 
-from cli.screens.run import _inject_status_plugin, delete_artifacts, _reload_modules
+import pytest
+
+from cli.screens.run import RunScreen, _inject_status_plugin, delete_artifacts, _reload_modules
 from cli.status_plugin import CLIStatusPlugin
+from cli.utils import create_experiment_scaffolding
 from crystallize import data_source, pipeline_step
 from crystallize.experiments.experiment import Experiment
 from crystallize.pipelines.pipeline import Pipeline
@@ -36,7 +42,7 @@ class DummyApp:
         func(*args, **kwargs)
 
 
-def test_delete_artifacts(tmp_path: Path):
+def test_delete_artifacts(tmp_path: Path) -> None:
     plugin = ArtifactPlugin(root_dir=str(tmp_path))
     exp = Experiment(datasource=dummy_source(), pipeline=Pipeline([add_one()]), name="e", plugins=[plugin])
     exp.validate()
@@ -46,13 +52,13 @@ def test_delete_artifacts(tmp_path: Path):
     assert not path.exists()
 
 
-def test_inject_status_plugin_adds_experiment(tmp_path: Path):
+def test_inject_status_plugin_adds_experiment(tmp_path: Path) -> None:
     plugin = ArtifactPlugin(root_dir=str(tmp_path))
     exp = Experiment(datasource=dummy_source(), pipeline=Pipeline([add_one()]), name="exp", plugins=[plugin])
     exp.validate()
-    events = []
+    events: list[dict[str, Any]] = []
 
-    def cb(event, info):
+    def cb(event: str, info: dict[str, Any]) -> None:
         events.append(info)
 
     writer = WidgetWriter(DummyWidget(), DummyApp(), [])
@@ -63,7 +69,7 @@ def test_inject_status_plugin_adds_experiment(tmp_path: Path):
     assert events[0]["experiment"] == "exp"
 
 
-def test_reload_modules(tmp_path: Path):
+def test_reload_modules(tmp_path: Path) -> None:
     pkg_dir = tmp_path / "pkg"
     pkg_dir.mkdir()
     init_file = pkg_dir / "__init__.py"
@@ -79,3 +85,113 @@ def test_reload_modules(tmp_path: Path):
     assert mod2.VALUE == 2
     sys.path.remove(str(tmp_path))
     sys.modules.pop("pkg", None)
+
+
+class StubNode:
+    def __init__(self, label: str, data: Any | None = None) -> None:
+        self.label = label
+        self.data = data
+        self.children: list[StubNode] = []
+
+    def add(self, label: str, data: Any | None = None) -> StubNode:
+        node = StubNode(label, data)
+        self.children.append(node)
+        return node
+
+    def set_label(self, label: str) -> None:
+        self.label = label
+
+    def expand(self) -> None:  # pragma: no cover - stub
+        pass
+
+
+class StubTree:
+    def __init__(self) -> None:
+        self.root = StubNode("root")
+        self.cursor_node: StubNode | None = None
+
+
+@pytest.mark.asyncio
+async def test_build_tree_and_toggle_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    exp_dir = create_experiment_scaffolding("demo", directory=tmp_path, examples=True)
+    cfg = exp_dir / "config.yaml"
+    monkeypatch.chdir(tmp_path)
+    obj = Experiment.from_yaml(cfg)
+    screen = RunScreen(obj, cfg, False, None)
+    tree = StubTree()
+    screen.query_one = lambda *_args, **_kwargs: tree  # type: ignore[assignment]
+    screen._reload_object()
+    screen._build_tree()
+    exp_name = obj.name
+    step_name = obj.pipeline.steps[0].__class__.__name__
+    assert (exp_name,) in screen.tree_nodes
+    assert (exp_name, step_name) in screen.tree_nodes
+
+
+@pytest.mark.asyncio
+async def test_handle_status_events_updates_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    exp_dir = create_experiment_scaffolding("demo", directory=tmp_path, examples=True)
+    cfg = exp_dir / "config.yaml"
+    monkeypatch.chdir(tmp_path)
+    obj = Experiment.from_yaml(cfg)
+    screen = RunScreen(obj, cfg, False, None)
+    step_name = obj.pipeline.steps[0].__class__.__name__
+    screen._handle_status_event("start", {"experiment": "demo", "steps": [step_name], "replicates": 2})
+    assert screen.experiment_states["demo"] == "running"
+    screen._handle_status_event("replicate", {"experiment": "demo", "replicate": 1, "total": 2, "condition": "t"})
+    assert screen.replicate_progress == (1, 2)
+    screen._handle_status_event("step", {"experiment": "demo", "step": step_name, "percent": 0.5})
+    assert screen.progress_percent == 0.5
+    assert "50%" in screen.top_bar
+    screen._handle_status_event("step_finished", {"experiment": "demo", "step": step_name})
+    assert screen.step_states[("demo", step_name)] == "completed"
+
+
+def test_run_or_cancel_behaviour(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    exp_dir = create_experiment_scaffolding("demo", directory=tmp_path, examples=True)
+    cfg = exp_dir / "config.yaml"
+    monkeypatch.chdir(tmp_path)
+    obj = Experiment.from_yaml(cfg)
+    screen = RunScreen(obj, cfg, False, None)
+    called = False
+
+    def fake_start() -> None:
+        nonlocal called
+        called = True
+
+    screen._start_run = fake_start  # type: ignore[assignment]
+    screen.action_run_or_cancel()
+    assert called
+
+    class DummyWorker:
+        is_finished = False
+        cancelled = False
+
+        def cancel(self) -> None:
+            self.cancelled = True
+
+    worker = DummyWorker()
+    screen.worker = worker
+    screen.action_run_or_cancel()
+    assert worker.cancelled
+
+
+def test_on_experiment_complete_opens_summary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    exp_dir = create_experiment_scaffolding("demo", directory=tmp_path, examples=True)
+    cfg = exp_dir / "config.yaml"
+    monkeypatch.chdir(tmp_path)
+    obj = Experiment.from_yaml(cfg)
+    screen = RunScreen(obj, cfg, False, None)
+    opened: list[Any] = []
+
+    def fake_open(res: Any) -> None:
+        opened.append(res)
+
+    btn = StubNode("Run")
+    screen.query_one = lambda *_a, **_k: btn  # type: ignore[assignment]
+    screen.open_summary_screen = fake_open  # type: ignore[assignment]
+    message = screen.ExperimentComplete(result=123)
+    screen.on_experiment_complete(message)
+    assert opened == [123]
+    assert screen.worker is None
+    assert btn.label == "Run"

--- a/tests/test_selection_screen.py
+++ b/tests/test_selection_screen.py
@@ -1,10 +1,13 @@
 import os
 import json
 from pathlib import Path
+
 import yaml
 import pytest
 from textual.app import App
-from textual.widgets import Static
+from textual.widgets import Static, Tree
+
+from cli.utils import create_experiment_scaffolding
 
 from cli.screens.selection import SelectionScreen
 from cli.widgets.config_editor import ConfigEditorWidget
@@ -55,3 +58,310 @@ async def test_update_details_mounts_widget(tmp_path: Path, monkeypatch) -> None
             assert "Estimated runtime" in str(details.renderable)
     finally:
         os.chdir(cwd)
+
+
+@pytest.mark.asyncio
+async def test_loads_with_no_experiments(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    async with App().run_test() as pilot:
+        screen = SelectionScreen()
+        await pilot.app.push_screen(screen)
+        await pilot.pause(1)
+        tree = screen.query_one("#object-tree", Tree)
+        assert not list(tree.root.children)
+
+
+@pytest.mark.asyncio
+async def test_loads_with_experiments(tmp_path: Path, monkeypatch) -> None:
+    exp1 = tmp_path / "exp1"
+    exp1.mkdir()
+    (exp1 / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "e1",
+                "cli": {"icon": "🧪", "group": "Experiments", "priority": 1},
+                "datasource": {},
+                "steps": ["s"],
+                "treatments": {},
+            }
+        )
+    )
+    exp2 = tmp_path / "exp2"
+    exp2.mkdir()
+    (exp2 / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "e2",
+                "cli": {"icon": "🧪", "group": "Experiments", "priority": 1},
+                "datasource": {},
+                "steps": ["s"],
+                "treatments": {},
+            }
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+    async with App().run_test() as pilot:
+        screen = SelectionScreen()
+        await pilot.app.push_screen(screen)
+        await pilot.pause(1)
+        tree = screen.query_one("#object-tree", Tree)
+        group = next(g for g in tree.root.children if g.label.plain == "Experiments")
+        for _ in range(10):
+            if len(group.children) >= 2:
+                break
+            await pilot.pause(0.1)
+        labels = [child.label.plain for child in group.children]
+        assert any("exp1 - e1" in label for label in labels)
+        assert any("exp2 - e2" in label for label in labels)
+
+
+@pytest.mark.asyncio
+async def test_estimated_time_multiple_runs(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    exp_dir = tmp_path / "exp"
+    exp_dir.mkdir()
+    cfg = exp_dir / "config.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {
+                "name": "exp",
+                "cli": {"icon": "🧪", "group": "Experiments", "priority": 1},
+                "datasource": {},
+                "steps": ["simple"],
+                "treatments": {},
+            }
+        )
+    )
+    hist_dir = tmp_path / ".cache" / "crystallize" / "steps"
+    hist_dir.mkdir(parents=True)
+    (hist_dir / "exp.json").write_text(json.dumps({"SimpleStep": [1.0, 3.0]}))
+
+    monkeypatch.chdir(tmp_path)
+    async with App().run_test() as pilot:
+        screen = SelectionScreen()
+        await pilot.app.push_screen(screen)
+        await pilot.pause(1)
+        tree = screen.query_one("#object-tree", Tree)
+        node = tree.root.children[0].children[0]
+        data = node.data
+        await screen._update_details(data)
+        details = screen.query_one("#details", Static)
+        assert "2s" in str(details.renderable)
+
+
+@pytest.mark.asyncio
+async def test_graph_estimated_time(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    e1 = tmp_path / "e1"
+    e1.mkdir()
+    (e1 / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "e1",
+                "cli": {"icon": "🧪", "group": "Experiments", "priority": 1},
+                "datasource": {},
+                "steps": ["a"],
+                "treatments": {},
+            }
+        )
+    )
+    graph_cfg = tmp_path / "config.yaml"
+    graph_cfg.write_text(
+        yaml.safe_dump(
+            {
+                "name": "graph",
+                "cli": {"icon": "📈", "group": "Graphs", "priority": 1},
+                "datasource": {"x": "e1#out"},
+                "steps": ["b"],
+                "treatments": {},
+            }
+        )
+    )
+    hist_dir = tmp_path / ".cache" / "crystallize" / "steps"
+    hist_dir.mkdir(parents=True)
+    (hist_dir / "e1.json").write_text(json.dumps({"AStep": [1.0]}))
+    (hist_dir / "graph.json").write_text(json.dumps({"BStep": [2.0]}))
+
+    monkeypatch.chdir(tmp_path)
+    async with App().run_test() as pilot:
+        screen = SelectionScreen()
+        await pilot.app.push_screen(screen)
+        await pilot.pause(1)
+        tree = screen.query_one("#object-tree", Tree)
+        # Second group should be graphs
+        graph_group = next(g for g in tree.root.children if g.label.plain == "Graphs")
+        node = graph_group.children[0]
+        await screen._update_details(node.data)
+        details = screen.query_one("#details", Static)
+        assert "3s" in str(details.renderable)
+
+
+@pytest.mark.asyncio
+async def test_refresh_updates_list(tmp_path: Path, monkeypatch) -> None:
+    exp = tmp_path / "exp"
+    exp.mkdir()
+    cfg = exp / "config.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {
+                "name": "old",
+                "cli": {"icon": "🧪", "group": "Experiments", "priority": 1},
+                "datasource": {},
+                "steps": ["s"],
+                "treatments": {},
+            }
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+    async with App().run_test() as pilot:
+        screen = SelectionScreen()
+        await pilot.app.push_screen(screen)
+        await pilot.pause(1)
+        tree = screen.query_one("#object-tree", Tree)
+        group = tree.root.children[0]
+        assert "old" in group.children[0].label.plain
+
+        data = yaml.safe_load(cfg.read_text())
+        data["name"] = "new"
+        cfg.write_text(yaml.safe_dump(data))
+        await pilot.press("r")
+        await pilot.pause(1)
+        tree = screen.query_one("#object-tree", Tree)
+        group = tree.root.children[0]
+        assert "new" in group.children[0].label.plain
+
+
+@pytest.mark.asyncio
+async def test_create_experiment_refreshes(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    async with App().run_test() as pilot:
+        screen = SelectionScreen()
+        await pilot.app.push_screen(screen)
+        await pilot.pause(1)
+
+        def fake_push(screen_obj, cb):
+            create_experiment_scaffolding("newexp", directory=Path("experiments"))
+            cb(None)
+
+        screen.app.push_screen = fake_push  # type: ignore[assignment]
+        await pilot.press("n")
+        await pilot.pause(1)
+        tree = screen.query_one("#object-tree", Tree)
+        group = tree.root.children[0]
+        labels = [child.label.plain for child in group.children]
+        assert any("newexp" in label for label in labels)
+
+
+@pytest.mark.asyncio
+async def test_details_edit_updates_config(tmp_path: Path, monkeypatch) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {
+                "name": "e",
+                "cli": {"icon": "🧪", "group": "Experiments", "priority": 1},
+                "datasource": {},
+                "steps": ["s"],
+                "treatments": {},
+            }
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+    async with App().run_test() as pilot:
+        screen = SelectionScreen()
+        await pilot.app.push_screen(screen)
+        await pilot.pause(1)
+        tree = screen.query_one("#object-tree", Tree)
+        node = tree.root.children[0].children[0]
+        await screen._update_details(node.data)
+        container = screen.query_one("#config-container")
+        widget = container.query_one(ConfigEditorWidget)
+        await pilot.pause(0.1)
+        steps_node = next(
+            c for c in widget.cfg_tree.root.children if str(c.label) == "steps"
+        )
+        leaf = steps_node.children[0]
+        widget.cfg_tree._cursor_node = leaf  # type: ignore[attr-defined]
+
+        async def fake_push(screen_obj, cb):
+            cb("t")
+
+        widget.app.push_screen = fake_push  # type: ignore[assignment]
+        await widget.action_edit()
+        data = yaml.safe_load(cfg.read_text())
+        assert data["steps"] == ["t"]
+
+
+@pytest.mark.asyncio
+async def test_update_details_missing_cli(tmp_path: Path, monkeypatch) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        yaml.safe_dump({"name": "e", "steps": ["s"], "treatments": {}, "datasource": {}})
+    )
+    monkeypatch.chdir(tmp_path)
+    async with App().run_test() as pilot:
+        screen = SelectionScreen()
+        await pilot.app.push_screen(screen)
+        await pilot.pause(1)
+        data = {
+            "path": str(cfg),
+            "label": "test",
+            "type": "Experiment",
+            "doc": "",
+        }
+        await screen._update_details(data)
+
+
+@pytest.mark.asyncio
+async def test_run_missing_step_shows_error(tmp_path: Path, monkeypatch) -> None:
+    exp = tmp_path / "exp"
+    exp.mkdir()
+    (exp / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "e",
+                "cli": {"icon": "🧪", "group": "Experiments", "priority": 1},
+                "datasource": {"x": "ds"},
+                "steps": ["missing"],
+                "treatments": {},
+            }
+        )
+    )
+    (exp / "steps.py").write_text("")
+    (exp / "datasources.py").write_text(
+        """
+def ds():
+    return 1
+"""
+    )
+    monkeypatch.chdir(tmp_path)
+    async with App().run_test() as pilot:
+        screen = SelectionScreen()
+        await pilot.app.push_screen(screen)
+        await pilot.pause(1)
+        tree = screen.query_one("#object-tree", Tree)
+        node = tree.root.children[0].children[0]
+        await screen._run_interactive_and_exit(node.data)
+        await pilot.pause(0.1)
+        err_screen = pilot.app.screen_stack[-1]
+        msg = err_screen.query_one("#error-msg", Static).renderable
+        assert "Verify your configuration" in str(msg)
+
+
+@pytest.mark.asyncio
+async def test_invalid_yaml_shows_error(tmp_path: Path, monkeypatch) -> None:
+    bad = tmp_path / "bad"
+    bad.mkdir()
+    (bad / "config.yaml").write_text("name: x:\n - bad")
+    monkeypatch.chdir(tmp_path)
+    async with App().run_test() as pilot:
+        screen = SelectionScreen()
+        await pilot.app.push_screen(screen)
+        await pilot.pause(1)
+        assert screen._load_errors
+        screen.action_show_errors()
+        await pilot.pause(0.1)
+        err_screen = pilot.app.screen_stack[-1]
+        msg = err_screen.query_one("#error-msg", Static).renderable
+        assert "Invalid YAML" in str(msg)


### PR DESCRIPTION
## 📖 Summary of Documentation Changes
- No documentation changes.

## ✏️ Changes
- Replace tree-based error screen with detailed modal
- Wrap load failures in `ExperimentLoadError` for clearer guidance
- Guard against missing selection and preserve numeric treatment values
- Expand selection screen tests for load failures and invalid configs

## ✅ Testing & Verification
- [x] `pixi run lint`
- [x] `pixi run test`
- [x] `pixi run cov`
- [x] `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_688e7594b6ec8329aea9c003caba940d