### PR TITLE
feat(cli): open steps in external editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ print(result.metrics)
 
 ### Command Line Interface
 
-The `crystallize` command opens a terminal UI for browsing and executing experiments. Highlight an experiment or graph to view its details and press <kbd>Enter</kbd> to run it. The details panel includes a live config editor so you can adjust values directly in `config.yaml`.
+The `crystallize` command opens a terminal UI for browsing and executing experiments. Highlight an experiment or graph to view its details and press <kbd>Enter</kbd> to run it. The details panel includes a live config editor so you can adjust values directly in `config.yaml`. While running, press <kbd>e</kbd> to open the selected step in your preferred editor (set `$EDITOR`).
 
 Experiments can define a `cli` section in `config.yaml` to control grouping and style:
 

--- a/docs/src/content/docs/cli/tutorial-cli-workflow.md
+++ b/docs/src/content/docs/cli/tutorial-cli-workflow.md
@@ -31,7 +31,7 @@ Let's run our new experiment without any modifications.
 
 1. Back on the main screen, your `hello-crystallize` experiment is highlighted. Press <kbd>Enter</kbd>.
 2. The **Prepare Run** screen appears. Make sure only **datasource** and **steps** are enabled and select `rerun` to execute everything from scratch.
-3. Press **Run** to start. The view switches to a live log, showing the pipeline for both the baseline and two example treatments. If something goes wrong while loading or running, the interface opens an **Errors** tab with the traceback so you can diagnose the issue.
+3. Press **Run** to start. The view switches to a live log, showing the pipeline for both the baseline and two example treatments. If something goes wrong while loading or running, the interface opens an **Errors** tab with the traceback so you can diagnose the issue. You can highlight any step in the tree and press <kbd>e</kbd> to open its source in your editor (set `$EDITOR`).
 
 ### Step 3: The Summary Tab – Instant Results!
 

--- a/tests/test_run_screen.py
+++ b/tests/test_run_screen.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import importlib
 import sys
 import time
@@ -10,6 +11,7 @@ import pytest
 from textual.app import App
 from textual.widgets import Button, RichLog, TabbedContent, TextArea, Tree
 
+import cli.screens.run as run_module
 from cli.screens.run import RunScreen, _inject_status_plugin, _reload_modules
 from cli.status_plugin import CLIStatusPlugin
 from cli.utils import create_experiment_scaffolding
@@ -662,3 +664,123 @@ async def test_start_run_load_error_shows_error_tab(
         tabs = screen.query_one("#output-tabs", TabbedContent)
         assert tabs.active == "errors"
         assert any("loadfail" in msg for msg in screen.error_history)
+
+
+@pytest.mark.parametrize(
+    ("editor", "expected"),
+    [
+        ("code", ["code", "-g", "dummy:7"]),
+        ("vim", ["vim", "+7", "dummy"]),
+    ],
+)
+def test_open_in_editor_builds_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, editor: str, expected: list[str]
+) -> None:
+    called: dict[str, list[str]] = {}
+
+    def fake_run(cmd, check=False):
+        called["cmd"] = cmd
+
+    monkeypatch.setattr(run_module, "pristine_stdio", contextlib.nullcontext)
+    monkeypatch.setattr(run_module, "_suspend_tui", contextlib.nullcontext)
+    monkeypatch.setattr(run_module.subprocess, "run", fake_run)
+    monkeypatch.setenv("EDITOR", editor)
+    run_module._open_in_editor("dummy", 7)
+    assert called["cmd"] == expected
+
+
+@pytest.mark.asyncio
+async def test_action_edit_step_opens_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    datasources = tmp_path / "datasources.py"
+    datasources.write_text(
+        "from crystallize import data_source\n\n@data_source\ndef source(ctx):\n    return 0\n"
+    )
+    steps = tmp_path / "steps.py"
+    steps.write_text(
+        "from crystallize import pipeline_step\n\n@pipeline_step()\ndef add_one(data, ctx):\n    return data + 1\n"
+    )
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        """
+name: exp
+datasource:
+  x: source
+steps:
+  - add_one
+"""
+    )
+    exp = Experiment.from_yaml(cfg)
+    screen = RunScreen(exp, cfg, False, None)
+
+    recorded: dict[str, Any] = {}
+
+    def fake_open(path: str, line: int | None = None) -> None:
+        recorded["path"] = path
+        recorded["line"] = line
+
+    monkeypatch.setattr(run_module, "_open_in_editor", fake_open)
+    monkeypatch.setenv("EDITOR", "echo")
+
+    class TestApp(App):
+        async def on_mount(self) -> None:  # pragma: no cover - test helper
+            await self.push_screen(screen)
+
+    app = TestApp()
+    async with app.run_test() as pilot:
+        screen._build_tree()
+        tree = screen.query_one("#node-tree", Tree)
+        step_node = tree.root.children[0].children[0]
+        monkeypatch.setattr(Tree, "cursor_node", property(lambda self: step_node))
+        screen.action_edit_step()
+
+    assert recorded["path"].endswith(".py")
+    assert recorded["line"] > 0
+
+
+@pytest.mark.asyncio
+async def test_action_edit_step_no_editor_shows_hint_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    datasources = tmp_path / "datasources.py"
+    datasources.write_text(
+        "from crystallize import data_source\n\n@data_source\ndef source(ctx):\n    return 0\n"
+    )
+    steps = tmp_path / "steps.py"
+    steps.write_text(
+        "from crystallize import pipeline_step\n\n@pipeline_step()\ndef add_one(data, ctx):\n    return data + 1\n"
+    )
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        """
+name: exp
+datasource:
+  x: source
+steps:
+  - add_one
+"""
+    )
+    exp = Experiment.from_yaml(cfg)
+    screen = RunScreen(exp, cfg, False, None)
+
+    messages: list[str] = []
+    monkeypatch.setattr(RunScreen, "_write_error", lambda self, text: messages.append(text))
+    for var in ("CRYSTALLIZE_EDITOR", "EDITOR", "VISUAL"):
+        monkeypatch.delenv(var, raising=False)
+
+    class TestApp(App):
+        async def on_mount(self) -> None:  # pragma: no cover - test helper
+            await self.push_screen(screen)
+
+    app = TestApp()
+    async with app.run_test() as pilot:
+        screen._build_tree()
+        tree = screen.query_one("#node-tree", Tree)
+        step_node = tree.root.children[0].children[0]
+        monkeypatch.setattr(Tree, "cursor_node", property(lambda self: step_node))
+        screen.action_edit_step()
+        screen.action_edit_step()
+
+    assert messages[0] == "Set $EDITOR (e.g. export EDITOR=vim) to enable 'e' to open files."
+    assert messages[1] == "No editor configured"


### PR DESCRIPTION
## 📖 Summary of Documentation Changes
- document new `e` shortcut for opening steps in an external editor

## ✏️ Changes
- allow `e` binding to open the selected step in `$CRYSTALLIZE_EDITOR`, `$EDITOR`, or `$VISUAL`
- display a one-time hint when no editor is configured
- document the shortcut in README and CLI tutorial
- test editor command construction and hint behavior

## ✅ Testing & Verification
- [x] Reviewed changes locally
- [x] Verified links and references
- [ ] Requested review from relevant stakeholders (optional)

------
https://chatgpt.com/codex/tasks/task_e_68901bffc5a88329a8c16485315813e7