### PR TITLE
fix(cli): ensure run screen opens summary tab

### DIFF
--- a/tests/test_run_screen.py
+++ b/tests/test_run_screen.py
@@ -205,8 +205,11 @@ steps:
         await pilot.press("R")
         while screen.worker and not screen.worker.is_finished:
             await pilot.pause()
-        await pilot.pause()
         tabs = screen.query_one("#output-tabs", TabbedContent)
+        for _ in range(5):
+            if tabs.active == "summary":
+                break
+            await pilot.pause()
         assert tabs.active == "summary"
         await pilot.press("t")
         summary_rich = screen.query_one("#summary_log", RichLog)


### PR DESCRIPTION
## 📖 Summary of Documentation Changes
- N/A

## ✏️ Changes
- Ensure RunScreen switches to summary tab after experiment completion
- Restore editor helpers for editing steps and configurations
- Provide user hint when no editor is configured
- Stabilize run screen tests by waiting for summary tab activation

## ✅ Testing & Verification
- [x] `pixi run lint`
- [x] `pixi run test`
- [x] `pixi run cov`
- [x] `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_68902c374a748329ba4e84a9f4ef02b1