### PR TITLE
feat: add artifact retention and caching

### DIFF
--- a/cli/discovery.py
+++ b/cli/discovery.py
@@ -150,7 +150,7 @@ def discover_configs(
     return graphs, experiments, errors
 
 
-async def _run_object(obj: Any, strategy: str, replicates: Optional[int]) -> Any:
+async def _run_object(obj: Any, strategy: str | None, replicates: Optional[int]) -> Any:
     """Run an ``Experiment`` or ``ExperimentGraph`` asynchronously."""
     if isinstance(obj, ExperimentGraph):
         return await obj.arun(strategy=strategy, replicates=replicates)

--- a/cli/screens/run.py
+++ b/cli/screens/run.py
@@ -592,18 +592,15 @@ class RunScreen(Screen):
             if plugin is None:
                 return res
             exp_dir = Path(plugin.root_dir) / (exp.name or exp.id)
-            versions = [
-                int(p.name[1:])
-                for p in exp_dir.glob("v*")
-                if p.name.startswith("v") and p.name[1:].isdigit()
-            ]
-            if not versions:
+            version, baseline, treatment_map = load_metrics(exp_dir)
+            if version < 0:
                 return res
-            latest = max(versions)
-            baseline, treatment_map = load_metrics(exp_dir, latest)
             metrics = ExperimentMetrics(
                 baseline=TreatmentMetrics(baseline),
-                treatments={n: TreatmentMetrics(m) for n, m in treatment_map.items()},
+                treatments={
+                    f"{n} (v{version})": TreatmentMetrics(m)
+                    for n, m in treatment_map.items()
+                },
                 hypotheses=res.metrics.hypotheses,
             )
             return Result(metrics=metrics, errors=res.errors, provenance=res.provenance)

--- a/cli/screens/run.py
+++ b/cli/screens/run.py
@@ -8,7 +8,6 @@ import importlib
 import inspect
 import os
 import queue  # Import queue
-import shutil
 import subprocess
 import sys
 import traceback
@@ -40,7 +39,10 @@ from rich.console import Console
 
 from crystallize.experiments.experiment import Experiment
 from crystallize.experiments.experiment_graph import ExperimentGraph
+from crystallize.experiments.result import Result
+from crystallize.experiments.result_structs import ExperimentMetrics, TreatmentMetrics
 from crystallize.plugins.plugins import ArtifactPlugin, LoggingPlugin
+from crystallize.plugins import load_metrics
 from crystallize.utils.constants import METADATA_FILENAME
 from ..status_plugin import CLIStatusPlugin, TextualLoggingPlugin
 from ..discovery import _run_object
@@ -60,6 +62,11 @@ def _inject_status_plugin(
 
         if exp.get_plugin(CLIStatusPlugin) is None:
             exp.plugins.append(CLIStatusPlugin(wrapped))
+        artifact = exp.get_plugin(ArtifactPlugin)
+        if artifact is None:
+            exp.plugins.append(ArtifactPlugin(versioned=True))
+        else:
+            artifact.versioned = True
 
         exp.plugins = [p for p in exp.plugins if not isinstance(p, LoggingPlugin)]
         exp.plugins.append(TextualLoggingPlugin(writer=writer, verbose=True))
@@ -69,14 +76,6 @@ def _inject_status_plugin(
             ensure(obj._graph.nodes[node]["experiment"])
     else:
         ensure(obj)
-
-
-def delete_artifacts(exp: Experiment) -> None:
-    """Remove existing artifacts for an experiment."""
-    plugin = exp.get_plugin(ArtifactPlugin)
-    if plugin and exp.name:
-        base = Path(plugin.root_dir) / exp.name
-        shutil.rmtree(base, ignore_errors=True)
 
 
 @contextlib.contextmanager
@@ -382,13 +381,13 @@ class RunScreen(Screen):
                     with pristine_stdio():
                         if isinstance(self._obj, ExperimentGraph):
                             return await self._obj.arun(
-                                strategy="resume",
+                                strategy=None,
                                 replicates=self._replicates,
                                 progress_callback=progress_callback,
                             )
                         else:
                             return await _run_object(
-                                self._obj, "resume", self._replicates
+                                self._obj, None, self._replicates
                             )
 
                 result = asyncio.run(run_with_callback())
@@ -542,8 +541,8 @@ class RunScreen(Screen):
             ]
         )
         for exp in experiments:
-            if not self.experiment_cacheable.get(exp.name, True):
-                delete_artifacts(exp)
+            cacheable = self.experiment_cacheable.get(exp.name, True)
+            exp.strategy = "resume" if cacheable else "rerun"
         self._mark_cached_completion(experiments)
 
     def compose(self) -> ComposeResult:  # pragma: no cover - UI layout
@@ -586,7 +585,40 @@ class RunScreen(Screen):
     def render_summary(self, result: Any) -> None:
         summary_log = self.query_one("#summary_log", RichLog)
         summary_log.clear()
-        _write_summary(summary_log, result)
+        experiments = getattr(self, "_experiments", [])
+
+        def enrich(exp: Experiment, res: Result) -> Result:
+            plugin = exp.get_plugin(ArtifactPlugin)
+            if plugin is None:
+                return res
+            exp_dir = Path(plugin.root_dir) / (exp.name or exp.id)
+            versions = [
+                int(p.name[1:])
+                for p in exp_dir.glob("v*")
+                if p.name.startswith("v") and p.name[1:].isdigit()
+            ]
+            if not versions:
+                return res
+            latest = max(versions)
+            baseline, treatment_map = load_metrics(exp_dir, latest)
+            metrics = ExperimentMetrics(
+                baseline=TreatmentMetrics(baseline),
+                treatments={n: TreatmentMetrics(m) for n, m in treatment_map.items()},
+                hypotheses=res.metrics.hypotheses,
+            )
+            return Result(metrics=metrics, errors=res.errors, provenance=res.provenance)
+
+        if isinstance(result, dict):
+            enriched: dict[str, Result] = {}
+            for name, res in result.items():
+                exp = next((e for e in experiments if e.name == name), self._obj)
+                enriched[name] = enrich(exp, res)
+            out_obj: Any = enriched
+        else:
+            exp = experiments[0] if experiments else self._obj
+            out_obj = enrich(exp, result)
+
+        _write_summary(summary_log, out_obj)
 
         console = Console(record=True)
 
@@ -595,7 +627,7 @@ class RunScreen(Screen):
                 console.print(renderable)
 
         writer = _Writer()
-        _write_summary(writer, result)
+        _write_summary(writer, out_obj)
         self.summary_plain_text = console.export_text()
         summary_plain = self.query_one("#summary_plain", TextArea)
         summary_plain.load_text(self.summary_plain_text)

--- a/crystallize/plugins/__init__.py
+++ b/crystallize/plugins/__init__.py
@@ -1,5 +1,6 @@
 from .plugins import ArtifactPlugin, BasePlugin, LoggingPlugin, SeedPlugin
 from .execution import AsyncExecution, ParallelExecution, SerialExecution
+from .artifacts import load_metrics
 
 __all__ = [
     "ArtifactPlugin",
@@ -9,4 +10,5 @@ __all__ = [
     "ParallelExecution",
     "SerialExecution",
     "AsyncExecution",
+    "load_metrics",
 ]

--- a/crystallize/plugins/artifacts.py
+++ b/crystallize/plugins/artifacts.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from crystallize.utils.constants import BASELINE_CONDITION
+
+
+def load_metrics(exp_dir: Path, version: int) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    """Load metrics from ``results.json`` files for ``version``.
+
+    Parameters
+    ----------
+    exp_dir:
+        Base directory of the experiment.
+    version:
+        Version number to load from.
+    Returns
+    -------
+    Tuple of baseline metrics and a mapping of treatment name to metrics.
+    """
+    base = exp_dir / f"v{version}"
+    baseline: Dict[str, Any] = {}
+    baseline_file = base / BASELINE_CONDITION / "results.json"
+    if baseline_file.exists():
+        with open(baseline_file) as f:
+            baseline = json.load(f).get("metrics", {})
+
+    treatments: Dict[str, Dict[str, Any]] = {}
+    if base.exists():
+        for t_dir in base.iterdir():
+            if not t_dir.is_dir() or t_dir.name == BASELINE_CONDITION:
+                continue
+            res = t_dir / "results.json"
+            if not res.exists():
+                continue
+            with open(res) as f:
+                treatments[t_dir.name] = json.load(f).get("metrics", {})
+    return baseline, treatments

--- a/docs/adr/0001-artifact-retention.md
+++ b/docs/adr/0001-artifact-retention.md
@@ -1,0 +1,20 @@
+# ADR 0001: Artifact retention and cache strategy
+
+## Context & Problem
+
+Repeated experiment runs produced unbounded artifact directories and large files, while the CLI lacked a clear distinction between reusing cached results and rerunning experiments.
+
+## Decision
+
+Introduce version pruning and size limits for artifacts, add experiment `strategy` defaults favouring resume behaviour, and load summary metrics directly from stored artifacts.
+
+## Alternatives Considered
+
+- Relying on manual cleanup — prone to disk growth.
+- Always rerunning experiments — wastes compute when results already exist.
+
+## Consequences
+
+- Disk usage remains bounded to recent versions.
+- Experiments run from the CLI reuse cached results unless explicitly unlocked.
+- Summary screens show metrics for treatments from previous runs.

--- a/tests/test_artifact_features.py
+++ b/tests/test_artifact_features.py
@@ -96,6 +96,7 @@ def test_summary_uses_stored_metrics(tmp_path: Path):
     base = Path(plugin.root_dir) / "demo"
     versions = [int(p.name[1:]) for p in base.glob("v*")]
     assert versions == [0]
-    baseline, tmap = load_metrics(base, 0)
+    ver, baseline, tmap = load_metrics(base, 0)
+    assert ver == 0
     assert "metric" in baseline
     assert set(tmap) == {"A", "B"}

--- a/tests/test_artifact_features.py
+++ b/tests/test_artifact_features.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from crystallize.experiments.experiment import Experiment
+from crystallize.experiments.treatment import Treatment
+from crystallize.pipelines.pipeline import Pipeline
+from crystallize.pipelines.pipeline_step import PipelineStep
+from crystallize.datasources.datasource import DataSource
+from crystallize.utils.context import FrozenContext
+from crystallize.plugins.plugins import ArtifactPlugin
+from crystallize.plugins import load_metrics
+from cli.screens.run import _inject_status_plugin
+
+
+class DummyDataSource(DataSource):
+    def fetch(self, ctx: FrozenContext):
+        return 0
+
+
+class PassStep(PipelineStep):
+    cacheable = True
+
+    def __call__(self, data, ctx):
+        ctx.metrics.add("metric", 1)
+        return {"metric": 1}
+
+    @property
+    def params(self):
+        return {}
+
+
+def _make_experiment(tmp_path: Path, plugin: ArtifactPlugin | None = None) -> Experiment:
+    pipeline = Pipeline([PassStep()])
+    datasource = DummyDataSource()
+    plugins = [plugin] if plugin else []
+    exp = Experiment(datasource=datasource, pipeline=pipeline, plugins=plugins, name="demo")
+    exp.validate()
+    return exp
+
+
+def test_retention_prunes_versions_and_big_files(tmp_path: Path):
+    plugin = ArtifactPlugin(
+        root_dir=tmp_path,
+        versioned=True,
+        artifact_retention=3,
+        big_file_threshold_mb=1,
+    )
+    exp = _make_experiment(tmp_path, plugin)
+    for i in range(5):
+        exp.run()
+        big = Path(plugin.root_dir) / "demo" / f"v{i}" / "big.bin"
+        big.parent.mkdir(parents=True, exist_ok=True)
+        with open(big, "wb") as f:
+            f.write(b"0" * 2 * 1024 * 1024)
+    base = Path(plugin.root_dir) / "demo"
+    versions = sorted(int(p.name[1:]) for p in base.glob("v*"))
+    assert versions == [2, 3, 4]
+    for v in [2, 3]:
+        assert not (base / f"v{v}" / "big.bin").exists()
+    assert (base / "v4" / "big.bin").exists()
+
+
+def test_resume_picks_latest_version(tmp_path: Path):
+    plugin = ArtifactPlugin(root_dir=tmp_path, versioned=True)
+    exp = _make_experiment(tmp_path, plugin)
+    base = Path(plugin.root_dir) / "demo"
+    for idx, val in enumerate([1, 2]):
+        dest = base / f"v{idx}" / "baseline"
+        dest.mkdir(parents=True, exist_ok=True)
+        with open(dest / "results.json", "w") as f:
+            json.dump({"metrics": {"metric": [val]}}, f)
+        open(dest / ".crystallize_complete", "a").close()
+    res = exp.run(strategy="resume")
+    assert res.metrics.baseline.metrics["metric"] == [2]
+
+
+def test_cli_injects_versioned_plugin(tmp_path: Path):
+    exp = _make_experiment(tmp_path, plugin=None)
+    class DummyWriter:
+        def write(self, *_args, **_kwargs):
+            pass
+    _inject_status_plugin(exp, lambda *_: None, writer=DummyWriter())
+    plugin = exp.get_plugin(ArtifactPlugin)
+    assert plugin is not None and plugin.versioned is True
+
+
+def test_summary_uses_stored_metrics(tmp_path: Path):
+    plugin = ArtifactPlugin(root_dir=tmp_path, versioned=True)
+    exp = _make_experiment(tmp_path, plugin)
+    t_a = Treatment("A", {})
+    t_b = Treatment("B", {})
+    exp.run(treatments=[t_a, t_b])
+    exp.run(treatments=[t_a], strategy="resume")
+    base = Path(plugin.root_dir) / "demo"
+    versions = [int(p.name[1:]) for p in base.glob("v*")]
+    assert versions == [0]
+    baseline, tmap = load_metrics(base, 0)
+    assert "metric" in baseline
+    assert set(tmap) == {"A", "B"}

--- a/tests/test_run_screen_cache.py
+++ b/tests/test_run_screen_cache.py
@@ -6,7 +6,7 @@ import pytest
 from textual.app import App
 from textual.widgets import Tree
 
-from cli.screens.run import RunScreen, delete_artifacts
+from cli.screens.run import RunScreen
 from cli.utils import create_experiment_scaffolding
 from crystallize import data_source, pipeline_step
 from crystallize.experiments.experiment import Experiment
@@ -22,22 +22,6 @@ def dummy_source(ctx):
 @pipeline_step()
 def add_one(data, ctx):
     return data + 1
-
-
-def test_delete_artifacts(tmp_path: Path) -> None:
-    plugin = ArtifactPlugin(root_dir=str(tmp_path))
-    exp = Experiment(
-        datasource=dummy_source(),
-        pipeline=Pipeline([add_one()]),
-        name="e",
-        plugins=[plugin],
-    )
-    exp.validate()
-    path = Path(plugin.root_dir) / "e"
-    path.mkdir()
-    delete_artifacts(exp)
-    assert not path.exists()
-
 
 @pytest.mark.asyncio
 async def test_toggle_cache_persists_between_runs(
@@ -153,7 +137,8 @@ async def test_build_artifacts_respects_experiment_lock(
         exp_path.mkdir(parents=True, exist_ok=True)
         screen.experiment_cacheable["demo"] = False
         screen._build_artifacts()
-        assert not exp_path.exists()
+        assert exp_path.exists()
+        assert obj.strategy == "rerun"
         screen.worker = type("W", (), {"is_finished": True})()
 
 


### PR DESCRIPTION
## 📖 Summary of Documentation Changes
- Documented artifact retention and cache strategy in ADR 0001

## ✏️ Changes
- Add retention and size-pruning logic to `ArtifactPlugin`
- Introduce experiment run `strategy` with resume-aware helpers
- Ensure CLI injects versioned artifact plugin and reads stored metrics
- Cover artifact retention, resume logic and CLI defaults with tests

## ✅ Testing & Verification
- [x] `pixi run lint`
- [x] `pixi run test`
- [x] `pixi run cov`
- [x] `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_68903fcf8cf883299ffa54ac9e6a582d