### PR TITLE
feat(cli): add treatment panel toggling and summary

### DIFF
--- a/cli/screens/style/run.py
+++ b/cli/screens/style/run.py
@@ -10,7 +10,7 @@ CSS = """
     padding-top: 1;
 }
 
-#node-tree {
+#exp-tree, #treatment-tree {
     height: 1fr;
 }
 

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -24,7 +24,7 @@ def _build_experiment_table(
     table.add_column("Metric", style="cyan")
     table.add_column("Baseline", style="magenta")
     for t in treatments:
-        base = t.split(" (v")[0]
+        base = t.rsplit(" (v", 1)[0]
         color = "red" if inactive and base in inactive else "green"
         table.add_column(t, style=color)
     metric_names = set(metrics.baseline.metrics)
@@ -105,6 +105,16 @@ def _write_experiment_summary(
             log.write(Text(f"{cond}:\n{traceback_str}", style="bold yellow"))
 
 
+def _has_output(result: Any) -> bool:
+    if _build_experiment_table(result) is not None:
+        return True
+    if _build_hypothesis_tables(result):
+        return True
+    if result.errors:
+        return True
+    return False
+
+
 def _write_summary(
     log: RichLog,
     result: Any,
@@ -114,6 +124,8 @@ def _write_summary(
 ) -> None:
     if isinstance(result, dict):
         for name, res in result.items():
+            if not _has_output(res):
+                continue
             log.write(Text(name, style="bold underline"))
             _write_experiment_summary(
                 log, res, highlight=highlight, inactive=inactive

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -112,21 +112,12 @@ def _write_summary(
     highlight: str | None = None,
     inactive: set[str] | None = None,
 ) -> None:
-    def _has_output(res: Any) -> bool:
-        table = _build_experiment_table(res, highlight=highlight, inactive=inactive)
-        return (
-            table is not None
-            or bool(res.metrics.hypotheses)
-            or bool(res.errors)
-        )
-
     if isinstance(result, dict):
         for name, res in result.items():
-            if _has_output(res):
-                log.write(Text(name, style="bold underline"))
-                _write_experiment_summary(
-                    log, res, highlight=highlight, inactive=inactive
-                )
+            log.write(Text(name, style="bold underline"))
+            _write_experiment_summary(
+                log, res, highlight=highlight, inactive=inactive
+            )
     else:
         _write_experiment_summary(log, result, highlight=highlight, inactive=inactive)
 

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -112,27 +112,21 @@ def _write_summary(
     highlight: str | None = None,
     inactive: set[str] | None = None,
 ) -> None:
+    def _has_output(res: Any) -> bool:
+        table = _build_experiment_table(res, highlight=highlight, inactive=inactive)
+        return (
+            table is not None
+            or bool(res.metrics.hypotheses)
+            or bool(res.errors)
+        )
+
     if isinstance(result, dict):
         for name, res in result.items():
-            table = _build_experiment_table(
-                res, highlight=highlight, inactive=inactive
-            )
-            has_table = table is not None or bool(res.metrics.hypotheses)
-            has_errors = bool(res.errors)
-
-            if has_table or has_errors:
+            if _has_output(res):
                 log.write(Text(name, style="bold underline"))
-                if table:
-                    log.write(table)
-                    log.write("\n")
-                for hyp_table in _build_hypothesis_tables(res):
-                    log.write(hyp_table)
-                    log.write("\n")
-                if res.errors:
-                    log.write(Text("Errors occurred", style="bold red"))
-                    for cond, err in res.errors.items():
-                        traceback_str = getattr(err, "traceback_str", str(err))
-                        log.write(Text(f"{cond}:\n{traceback_str}", style="bold yellow"))
+                _write_experiment_summary(
+                    log, res, highlight=highlight, inactive=inactive
+                )
     else:
         _write_experiment_summary(log, result, highlight=highlight, inactive=inactive)
 

--- a/cli/yaml_edit.py
+++ b/cli/yaml_edit.py
@@ -26,7 +26,8 @@ def find_treatment_line(path: Path, name: str) -> int:
 
 
 def ensure_new_treatment_placeholder(path: Path) -> int:
-    lines = path.read_text().splitlines()
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
     treat_idx = None
     indent = ""
     for i, line in enumerate(lines):
@@ -48,5 +49,6 @@ def ensure_new_treatment_placeholder(path: Path) -> int:
     placeholder = f"{indent}# new treatment"
     if insert >= len(lines) or lines[insert].strip() != "# new treatment":
         lines.insert(insert, placeholder)
-    path.write_text("\n".join(lines) + "\n")
+    newline = "\n" if text.endswith("\n") else ""
+    path.write_text("\n".join(lines) + newline, encoding="utf-8")
     return insert + 1

--- a/cli/yaml_edit.py
+++ b/cli/yaml_edit.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+import yaml
+
+
+def find_treatment_line(path: Path, name: str) -> int:
+    try:
+        lines = path.read_text().splitlines()
+    except Exception:
+        return 1
+    in_block = False
+    indent = ""
+    for i, line in enumerate(lines, 1):
+        stripped = line.strip()
+        if stripped.startswith("treatments:"):
+            in_block = True
+            indent = line[: len(line) - len(stripped)] + "  "
+            continue
+        if in_block:
+            if stripped and not line.startswith(indent):
+                break
+            if stripped.startswith(f"{name}:"):
+                return i
+    return 1
+
+
+def ensure_new_treatment_placeholder(path: Path) -> int:
+    text = path.read_text()
+    try:
+        yaml.safe_load(text)
+    except Exception:
+        pass
+    lines = text.splitlines()
+    treat_idx = None
+    indent = ""
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("treatments:"):
+            treat_idx = i
+            indent = line[: len(line) - len(stripped)] + "  "
+            break
+    if treat_idx is None:
+        lines.append("treatments:")
+        treat_idx = len(lines) - 1
+    insert = treat_idx + 1
+    for i in range(treat_idx + 1, len(lines)):
+        line = lines[i]
+        if line.strip() and not line.startswith(indent):
+            insert = i
+            break
+        insert = i + 1
+    placeholder = f"{indent}# new treatment"
+    if insert >= len(lines) or lines[insert].strip() != "# new treatment":
+        lines.insert(insert, placeholder)
+    path.write_text("\n".join(lines) + "\n")
+    return insert + 1

--- a/cli/yaml_edit.py
+++ b/cli/yaml_edit.py
@@ -26,12 +26,7 @@ def find_treatment_line(path: Path, name: str) -> int:
 
 
 def ensure_new_treatment_placeholder(path: Path) -> int:
-    text = path.read_text()
-    try:
-        yaml.safe_load(text)
-    except Exception:
-        pass
-    lines = text.splitlines()
+    lines = path.read_text().splitlines()
     treat_idx = None
     indent = ""
     for i, line in enumerate(lines):

--- a/cli/yaml_edit.py
+++ b/cli/yaml_edit.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-import yaml
 
 
 def find_treatment_line(path: Path, name: str) -> int:
@@ -52,3 +51,31 @@ def ensure_new_treatment_placeholder(path: Path) -> int:
     newline = "\n" if text.endswith("\n") else ""
     path.write_text("\n".join(lines) + newline, encoding="utf-8")
     return insert + 1
+
+
+def find_treatment_apply_line(path: Path, name: str, key: str) -> int:
+    try:
+        lines = path.read_text().splitlines()
+    except Exception:
+        return 1
+    in_block = False
+    block_indent = ""
+    t_indent = ""
+    for i, line in enumerate(lines, 1):
+        stripped = line.strip()
+        if stripped.startswith("treatments:"):
+            in_block = True
+            block_indent = line[: len(line) - len(stripped)] + "  "
+            continue
+        if in_block and t_indent:
+            if stripped and not line.startswith(t_indent):
+                break
+            if stripped.startswith(f"{key}:"):
+                return i
+            continue
+        if in_block:
+            if stripped and not line.startswith(block_indent):
+                break
+            if stripped.startswith(f"{name}:"):
+                t_indent = line[: len(line) - len(stripped)] + "  "
+    return 1

--- a/crystallize/experiments/treatment.py
+++ b/crystallize/experiments/treatment.py
@@ -43,8 +43,9 @@ class Treatment:
 
     @property
     def apply_map(self) -> dict[str, Any]:
-        items = getattr(self._apply_fn, "items", {})
-        return dict(items) if isinstance(items, Mapping) else {}
+        if isinstance(self._apply_fn, _MappingApplier):
+            return dict(self._apply_fn.items)
+        return {}
 
     # ---- framework use --------------------------------------------------
 

--- a/crystallize/experiments/treatment.py
+++ b/crystallize/experiments/treatment.py
@@ -1,8 +1,8 @@
 from typing import Any, Callable, Mapping, Union
+
 from crystallize.utils.context import FrozenContext
 
 
-# Add this helper class at the top of the file
 class _MappingApplier:
     """A picklable callable that applies a mapping to a context."""
 
@@ -40,6 +40,11 @@ class Treatment:
         else:
 
             self._apply_fn = _MappingApplier(apply)
+
+    @property
+    def apply_map(self) -> dict[str, Any]:
+        items = getattr(self._apply_fn, "items", {})
+        return dict(items) if isinstance(items, Mapping) else {}
 
     # ---- framework use --------------------------------------------------
 

--- a/crystallize/plugins/__init__.py
+++ b/crystallize/plugins/__init__.py
@@ -1,6 +1,6 @@
 from .plugins import ArtifactPlugin, BasePlugin, LoggingPlugin, SeedPlugin
 from .execution import AsyncExecution, ParallelExecution, SerialExecution
-from .artifacts import load_metrics
+from .artifacts import load_metrics, load_all_metrics
 
 __all__ = [
     "ArtifactPlugin",
@@ -11,4 +11,5 @@ __all__ = [
     "SerialExecution",
     "AsyncExecution",
     "load_metrics",
+    "load_all_metrics",
 ]

--- a/crystallize/plugins/artifacts.py
+++ b/crystallize/plugins/artifacts.py
@@ -49,3 +49,62 @@ def load_metrics(exp_dir: Path, version: int | None = None) -> Tuple[int, dict[s
             with open(res) as f:
                 treatments[t_dir.name] = json.load(f).get("metrics", {})
     return version, baseline, treatments
+
+
+def load_all_metrics(
+    exp_dir: Path, version: int | None = None
+) -> Tuple[int, dict[str, Any], dict[str, Tuple[int, dict[str, Any]]]]:
+    """Load metrics for all treatments across versions.
+
+    Parameters
+    ----------
+    exp_dir:
+        Base directory of the experiment.
+    version:
+        Latest version to consider. If ``None`` the newest version on disk is
+        used.
+
+    Returns
+    -------
+    Tuple of the latest version number, baseline metrics from that version and a
+    mapping of treatment name to a tuple of ``(version, metrics)`` where
+    ``version`` indicates which artifact version the metrics were loaded from.
+    """
+
+    versions = sorted(
+        int(p.name[1:])
+        for p in exp_dir.glob("v*")
+        if p.name.startswith("v") and p.name[1:].isdigit()
+    )
+    if not versions:
+        return -1, {}, {}
+
+    latest = max(versions) if version is None else version
+    base = exp_dir / f"v{latest}"
+    baseline: Dict[str, Any] = {}
+    baseline_file = base / BASELINE_CONDITION / "results.json"
+    if baseline_file.exists():
+        with open(baseline_file) as f:
+            baseline = json.load(f).get("metrics", {})
+
+    treatments: Dict[str, Tuple[int, Dict[str, Any]]] = {}
+    seen: set[str] = set()
+    for ver in sorted((v for v in versions if v <= latest), reverse=True):
+        base = exp_dir / f"v{ver}"
+        if not base.exists():
+            continue
+        for t_dir in sorted(base.iterdir(), key=lambda p: p.name):
+            name = t_dir.name
+            if (
+                not t_dir.is_dir()
+                or name == BASELINE_CONDITION
+                or name in seen
+            ):
+                continue
+            res = t_dir / "results.json"
+            if not res.exists():
+                continue
+            with open(res) as f:
+                treatments[name] = (ver, json.load(f).get("metrics", {}))
+            seen.add(name)
+    return latest, baseline, treatments

--- a/crystallize/plugins/plugins.py
+++ b/crystallize/plugins/plugins.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib
 import json
 import os
-import shutil
 from abc import ABC
 from dataclasses import dataclass
 from pathlib import Path
@@ -313,7 +312,7 @@ class ArtifactPlugin(BasePlugin):
             self._prune_large_files(base_parent / f"v{v}", threshold)
         for v in versions:
             if v not in keep:
-                shutil.rmtree(base_parent / f"v{v}", ignore_errors=True)
+                self._prune_to_metrics(base_parent / f"v{v}")
 
     def _prune_large_files(self, version_dir: Path, threshold: int) -> None:
         for f in version_dir.rglob("*"):
@@ -323,3 +322,14 @@ class ArtifactPlugin(BasePlugin):
                 continue
             if f.stat().st_size > threshold:
                 f.unlink()
+
+    def _prune_to_metrics(self, version_dir: Path) -> None:
+        for f in version_dir.rglob("*"):
+            if f.is_file() and f.name != "results.json":
+                f.unlink()
+        for d in sorted(version_dir.glob("**/*"), reverse=True):
+            if d.is_dir():
+                try:
+                    d.rmdir()
+                except OSError:
+                    pass

--- a/docs/adr/0002-treatment-panel.md
+++ b/docs/adr/0002-treatment-panel.md
@@ -4,7 +4,7 @@
 RunScreen lacked a way to activate, deactivate, or inspect treatments, and summaries omitted inactive treatments.
 
 ## Decision
-Persist inactive treatment names, expose them in the sidebar with color-coded toggles, and load metrics from disk so summaries include inactive treatments. Helpers manage YAML edits for adding new treatments.
+Persist inactive treatment names, expose them in the sidebar with color-coded toggles, and load metrics from the latest and prior artifact versions so summaries include treatments even after they are disabled. Helpers manage YAML edits for adding new treatments.
 
 ## Alternatives Considered
 - Only track treatment state in memory.

--- a/docs/adr/0002-treatment-panel.md
+++ b/docs/adr/0002-treatment-panel.md
@@ -1,0 +1,15 @@
+# ADR 0002: Treatment Panel Toggle and Summary Flow
+
+## Context & Problem
+RunScreen lacked a way to activate, deactivate, or inspect treatments, and summaries omitted inactive treatments.
+
+## Decision
+Persist inactive treatment names, expose them in the sidebar with color-coded toggles, and load metrics from disk so summaries include inactive treatments. Helpers manage YAML edits for adding new treatments.
+
+## Alternatives Considered
+- Only track treatment state in memory.
+- Embed YAML editing logic directly in RunScreen.
+
+## Consequences
+- Users can manage treatments without leaving the run UI.
+- Additional state file (`*.state.json`) per config and extra code paths to maintain.

--- a/docs/adr/0002-treatment-panel.md
+++ b/docs/adr/0002-treatment-panel.md
@@ -1,10 +1,10 @@
 # ADR 0002: Treatment Panel Toggle and Summary Flow
 
 ## Context & Problem
-RunScreen lacked a way to activate, deactivate, or inspect treatments, and summaries omitted inactive treatments.
+RunScreen lacked a way to activate, deactivate, or inspect treatments, and summaries omitted inactive treatments or failed to distinguish between the latest run and historical metrics.
 
 ## Decision
-Persist inactive treatment names, expose them in the sidebar with color-coded toggles, and load metrics from the latest and prior artifact versions so summaries include treatments even after they are disabled. Helpers manage YAML edits for adding new treatments.
+Persist inactive treatment names, expose them in the sidebar with color-coded toggles, and load metrics from the latest and prior artifact versions so summaries include treatments even after they are disabled. After a run completes the Summary tab shows only the treatments that just executed; pressing `S` reloads all treatments (active or not) using historical artifacts. Helpers manage YAML edits for adding new treatments.
 
 ## Alternatives Considered
 - Only track treatment state in memory.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -78,6 +78,7 @@ print(output)
 - Fluent builders and prod apply mode.
 - Optional parallel execution for heavy experiments.
 - Configurable worker count and executor type ("thread" or "process").
+- Run screen sidebar can toggle treatments (`x`), edit (`e`) and jump to the summary (`s`) with color-coded states.
 
 For heavy parallel workloads, ensure the cache directory supports file locks or
 switch to a thread-safe backend.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -78,7 +78,7 @@ print(output)
 - Fluent builders and prod apply mode.
 - Optional parallel execution for heavy experiments.
 - Configurable worker count and executor type ("thread" or "process").
-- Run screen sidebar can toggle treatments (`x`), edit (`e`) and jump to the summary (`s`) with color-coded states.
+- Run screen sidebar can toggle treatments (`x`), edit (`e`) and jump to the summary (`S`) with color-coded states.
 
 For heavy parallel workloads, ensure the cache directory supports file locks or
 switch to a thread-safe backend.

--- a/tests/test_artifact_features.py
+++ b/tests/test_artifact_features.py
@@ -10,7 +10,7 @@ from crystallize.pipelines.pipeline_step import PipelineStep
 from crystallize.datasources.datasource import DataSource
 from crystallize.utils.context import FrozenContext
 from crystallize.plugins.plugins import ArtifactPlugin
-from crystallize.plugins import load_metrics
+from crystallize.plugins import load_metrics, load_all_metrics
 from cli.screens.run import _inject_status_plugin
 
 
@@ -107,4 +107,7 @@ def test_summary_uses_stored_metrics(tmp_path: Path):
     assert set(tmap) == {"A", "B"}
 
     exp.run(treatments=[t_a], strategy="rerun")
+    hist_ver, _, hist_map = load_all_metrics(base)
+    assert hist_ver == 1
+    assert hist_map["A"][0] == 1 and hist_map["B"][0] == 0
     assert not big.exists()

--- a/tests/test_run_screen.py
+++ b/tests/test_run_screen.py
@@ -232,8 +232,8 @@ async def test_build_tree_and_toggle_cache(
         await pilot.app.push_screen(screen)
         screen.worker = type("W", (), {"is_finished": True})()
         screen._reload_object()
-        screen._build_tree()
-        tree = screen.query_one("#node-tree", Tree)
+        screen._build_trees()
+        tree = screen.query_one("#exp-tree", Tree)
         step_node = tree.root.children[0].children[0]
         tree.focus()
         tree._cursor_node = step_node  # type: ignore[attr-defined]
@@ -271,8 +271,8 @@ async def test_build_tree_shows_lock_for_cacheable_step(
         await pilot.app.push_screen(screen)
         screen.worker = type("W", (), {"is_finished": True})()
         screen._reload_object()
-        screen._build_tree()
-        tree = screen.query_one("#node-tree", Tree)
+        screen._build_trees()
+        tree = screen.query_one("#exp-tree", Tree)
         step_node = tree.root.children[0].children[0]
         assert "🔒" in step_node.label.plain
         screen.worker = type("W", (), {"is_finished": True})()
@@ -292,8 +292,8 @@ async def test_step_nodes_are_leaves(
         await pilot.app.push_screen(screen)
         screen.worker = type("W", (), {"is_finished": True})()
         screen._reload_object()
-        screen._build_tree()
-        tree = screen.query_one("#node-tree", Tree)
+        screen._build_trees()
+        tree = screen.query_one("#exp-tree", Tree)
         step_node = tree.root.children[0].children[0]
         assert not step_node.allow_expand
         screen.worker = type("W", (), {"is_finished": True})()
@@ -369,8 +369,8 @@ async def test_handle_status_events_updates_state(
         await pilot.app.push_screen(screen)
         screen.worker = type("W", (), {"is_finished": True})()
         screen._reload_object()
-        screen._build_tree()
-        tree = screen.query_one("#node-tree", Tree)
+        screen._build_trees()
+        tree = screen.query_one("#exp-tree", Tree)
         exp_name = obj.name
         exp_node = tree.root.children[0]
         step_name = obj.pipeline.steps[0].__class__.__name__
@@ -520,7 +520,7 @@ async def test_tree_expanded_shows_step_status_on_experiment(
         await pilot.app.push_screen(screen)
         screen.worker = type("W", (), {"is_finished": True})()
         screen._reload_object()
-        screen._build_tree()
+        screen._build_trees()
         exp_name = obj.name
         step_name = obj.pipeline.steps[0].__class__.__name__
         screen._handle_status_event(
@@ -547,8 +547,8 @@ async def test_tree_collapsed_shows_step_status_on_experiment(
         await pilot.app.push_screen(screen)
         screen.worker = type("W", (), {"is_finished": True})()
         screen._reload_object()
-        screen._build_tree()
-        tree = screen.query_one("#node-tree", Tree)
+        screen._build_trees()
+        tree = screen.query_one("#exp-tree", Tree)
         exp_name = obj.name
         exp_node = tree.root.children[0]
         step_name = obj.pipeline.steps[0].__class__.__name__
@@ -577,7 +577,7 @@ async def test_step_error_icon_displayed(
         await pilot.app.push_screen(screen)
         screen.worker = type("W", (), {"is_finished": True})()
         screen._reload_object()
-        screen._build_tree()
+        screen._build_trees()
         exp_name = obj.name
         step_name = obj.pipeline.steps[0].__class__.__name__
         screen.step_states[(exp_name, step_name)] = "errored"
@@ -733,10 +733,12 @@ steps:
 
     app = TestApp()
     async with app.run_test():
-        screen._build_tree()
-        tree = screen.query_one("#node-tree", Tree)
+        screen._build_trees()
+        tree = screen.query_one("#exp-tree", Tree)
         step_node = tree.root.children[0].children[0]
+        tree.focus()
         monkeypatch.setattr(Tree, "cursor_node", property(lambda self: step_node))
+        monkeypatch.setattr(RunScreen, "_focused_tree", lambda self: tree)
         screen.action_edit_step()
 
     assert recorded["path"].endswith(".py")
@@ -781,10 +783,12 @@ steps:
 
     app = TestApp()
     async with app.run_test():
-        screen._build_tree()
-        tree = screen.query_one("#node-tree", Tree)
+        screen._build_trees()
+        tree = screen.query_one("#exp-tree", Tree)
         step_node = tree.root.children[0].children[0]
+        tree.focus()
         monkeypatch.setattr(Tree, "cursor_node", property(lambda self: step_node))
+        monkeypatch.setattr(RunScreen, "_focused_tree", lambda self: tree)
         screen.action_edit_step()
         screen.action_edit_step()
 

--- a/tests/test_run_screen_cache.py
+++ b/tests/test_run_screen_cache.py
@@ -47,12 +47,13 @@ async def test_toggle_cache_persists_between_runs(
         screen = RunScreen(obj, cfg, False, None)
         await pilot.app.push_screen(screen)
         screen.worker = type("W", (), {"is_finished": True})()
-        tree = screen.query_one("#node-tree", Tree)
+        tree = screen.query_one("#exp-tree", Tree)
         tree.root.remove_children()
         screen._reload_object()
-        screen._build_tree()
-        tree = screen.query_one("#node-tree", Tree)
+        screen._build_trees()
+        tree = screen.query_one("#exp-tree", Tree)
         step_node = tree.root.children[0].children[0]
+        tree.focus()
         tree._cursor_node = step_node  # type: ignore[attr-defined]
         screen.action_toggle_cache()
         await screen._obj.arun()
@@ -99,9 +100,10 @@ async def test_all_steps_cache_when_toggled(
         screen._reload_object = lambda: None  # type: ignore[assignment]
         await pilot.app.push_screen(screen)
         screen.worker = type("W", (), {"is_finished": True})()
-        screen._build_tree()
-        tree = screen.query_one("#node-tree", Tree)
+        screen._build_trees()
+        tree = screen.query_one("#exp-tree", Tree)
         exp_node = tree.root.children[0]
+        tree.focus()
         for step_node in exp_node.children:
             tree._cursor_node = step_node  # type: ignore[attr-defined]
             screen.action_toggle_cache()
@@ -129,7 +131,7 @@ async def test_build_artifacts_respects_experiment_lock(
         screen._reload_object = lambda: None  # type: ignore[assignment]
         await pilot.app.push_screen(screen)
         screen.worker = type("W", (), {"is_finished": True})()
-        screen._build_tree()
+        screen._build_trees()
         exp_path = Path(plugin.root_dir) / "demo"
         exp_path.mkdir(parents=True)
         screen._build_artifacts()
@@ -165,7 +167,7 @@ async def test_resume_marks_completed(
         screen._reload_object = lambda: None  # type: ignore[assignment]
         await pilot.app.push_screen(screen)
         screen.worker = type("W", (), {"is_finished": True})()
-        tree = screen.query_one("#node-tree", Tree)
+        tree = screen.query_one("#exp-tree", Tree)
         exp_node = tree.root.children[0]
         step_node = exp_node.children[0]
         assert "✅" in exp_node.label.plain

--- a/tests/test_treatment_panel.py
+++ b/tests/test_treatment_panel.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import pytest
+from rich.style import Style
 from textual.app import App
 from textual.widgets import Tree
 
@@ -205,5 +206,5 @@ async def test_color_rendering(tmp_path: Path) -> None:
         )
         tree._cursor_node = node_b
         label_b = screen.action_toggle_treatment()
-        assert "color:green" in str(node_a.label.style)
-        assert label_b is not None and "color:red" in str(label_b.style)
+        assert Style.parse(node_a.label.style) == Style.parse("green")
+        assert label_b is not None and Style.parse(label_b.style) == Style.parse("red")

--- a/tests/test_treatment_panel.py
+++ b/tests/test_treatment_panel.py
@@ -2,7 +2,6 @@ import json
 from pathlib import Path
 
 import pytest
-from rich.style import Style
 from textual.app import App
 from textual.widgets import Tree
 
@@ -168,9 +167,8 @@ async def test_add_treatment_placeholder(tmp_path: Path, monkeypatch) -> None:
         plugin.root_dir = str(tmp_path)
         screen._build_tree()
         tree = screen.query_one("#node-tree", Tree)
-        node_add = next(
-            n for n in tree.root.children if n.data and n.data[0] == "add_treatment"
-        )
+        assert tree.root.children[-1].data[0] == "add_treatment"
+        node_add = tree.root.children[-1]
         tree._cursor_node = node_add
         monkeypatch.setattr("cli.screens.run._open_in_editor", lambda *a, **k: None)
         screen.action_edit_selected_node()
@@ -206,5 +204,5 @@ async def test_color_rendering(tmp_path: Path) -> None:
         )
         tree._cursor_node = node_b
         label_b = screen.action_toggle_treatment()
-        assert Style.parse(node_a.label.style) == Style.parse("green")
-        assert label_b is not None and Style.parse(label_b.style) == Style.parse("red")
+        assert str(node_a.label.style) == "green"
+        assert label_b is not None and str(label_b.style) == "red"

--- a/tests/test_treatment_panel.py
+++ b/tests/test_treatment_panel.py
@@ -1,0 +1,197 @@
+import json
+from pathlib import Path
+
+import pytest
+from textual.app import App
+from textual.widgets import Tree
+
+from cli.screens.run import RunScreen
+from crystallize import data_source, pipeline_step
+from crystallize.experiments.experiment import Experiment
+from crystallize.plugins.plugins import ArtifactPlugin
+
+
+@data_source
+def source(ctx):
+    return 0
+
+
+@pipeline_step()
+def metric_step(data, ctx):
+    ctx.metrics.add("score", data)
+    return data
+
+
+def _write_config(tmp_path: Path) -> Path:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        """
+name: exp
+datasource:
+  x: source
+steps:
+  - metric_step
+treatments:
+  treatment_a:
+    val: 1
+  treatment_b:
+    val: 2
+"""
+    )
+    datasources = tmp_path / "datasources.py"
+    datasources.write_text(
+        "from crystallize import data_source\n@data_source\ndef source(ctx):\n    return 0\n"
+    )
+    steps = tmp_path / "steps.py"
+    steps.write_text(
+        "from crystallize import pipeline_step\n@pipeline_step()\ndef metric_step(data, ctx):\n    ctx.metrics.add('score', data)\n    return data\n"
+    )
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_toggle_state_persistence(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    exp = Experiment.from_yaml(cfg)
+    plugin = exp.get_plugin(ArtifactPlugin)
+    plugin.root_dir = str(tmp_path)
+    screen = RunScreen(exp, cfg, False, None)
+
+    class TestApp(App):
+        async def on_mount(self) -> None:  # pragma: no cover - helper
+            await self.push_screen(screen)
+
+    app = TestApp()
+    async with app.run_test() as pilot:
+        screen._reload_object()
+        plugin = screen._obj.get_plugin(ArtifactPlugin)
+        plugin.root_dir = str(tmp_path)
+        screen._build_tree()
+        tree = screen.query_one("#node-tree", Tree)
+        node_b = next(
+            n for n in tree.root.children if n.data and n.data[1] == "treatment_b"
+        )
+        tree._cursor_node = node_b
+        screen.action_toggle_treatment()
+    state_path = cfg.with_suffix(".state.json")
+    data = json.loads(state_path.read_text())
+    assert data["inactive_treatments"] == ["treatment_b"]
+
+    exp2 = Experiment.from_yaml(cfg)
+    plugin2 = exp2.get_plugin(ArtifactPlugin)
+    plugin2.root_dir = str(tmp_path)
+    screen2 = RunScreen(exp2, cfg, False, None)
+
+    class TestApp2(App):
+        async def on_mount(self) -> None:  # pragma: no cover - helper
+            await self.push_screen(screen2)
+
+    app2 = TestApp2()
+    async with app2.run_test() as pilot:
+        screen2._reload_object()
+        plugin = screen2._obj.get_plugin(ArtifactPlugin)
+        plugin.root_dir = str(tmp_path)
+        screen2._build_tree()
+        assert "treatment_b" in screen2._inactive_treatments
+        assert [t.name for t in screen2._obj.treatments] == ["treatment_a"]
+
+
+@pytest.mark.asyncio
+async def test_summary_shows_inactive_metrics(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    exp_first = Experiment.from_yaml(cfg)
+    plugin = exp_first.get_plugin(ArtifactPlugin)
+    plugin.root_dir = str(tmp_path)
+    await exp_first.arun()
+
+    exp = Experiment.from_yaml(cfg)
+    plugin = exp.get_plugin(ArtifactPlugin)
+    plugin.root_dir = str(tmp_path)
+    screen = RunScreen(exp, cfg, False, None)
+
+    class AppTest(App):
+        async def on_mount(self) -> None:  # pragma: no cover - helper
+            await self.push_screen(screen)
+
+    app = AppTest()
+    async with app.run_test() as pilot:
+        screen._reload_object()
+        plugin = screen._obj.get_plugin(ArtifactPlugin)
+        plugin.root_dir = str(tmp_path)
+        screen._build_tree()
+        tree = screen.query_one("#node-tree", Tree)
+        node_b = next(
+            n for n in tree.root.children if n.data and n.data[1] == "treatment_b"
+        )
+        tree._cursor_node = node_b
+        screen.action_toggle_treatment()
+        screen._reload_object()
+        plugin = screen._obj.get_plugin(ArtifactPlugin)
+        plugin.root_dir = str(tmp_path)
+        result = await screen._obj.arun(strategy="resume")
+        screen._experiments = [screen._obj]
+        screen.render_summary(result, highlight="treatment_b")
+        text = screen.summary_plain_text
+        assert "treatment_a" in text and "treatment_b" in text
+        assert text.index("treatment_b") < text.index("treatment_a")
+
+
+@pytest.mark.asyncio
+async def test_add_treatment_placeholder(tmp_path: Path, monkeypatch) -> None:
+    cfg = _write_config(tmp_path)
+    exp = Experiment.from_yaml(cfg)
+    plugin = exp.get_plugin(ArtifactPlugin)
+    plugin.root_dir = str(tmp_path)
+    screen = RunScreen(exp, cfg, False, None)
+
+    class TestApp(App):
+        async def on_mount(self) -> None:  # pragma: no cover - helper
+            await self.push_screen(screen)
+
+    app = TestApp()
+    async with app.run_test() as pilot:
+        screen._reload_object()
+        plugin = screen._obj.get_plugin(ArtifactPlugin)
+        plugin.root_dir = str(tmp_path)
+        screen._build_tree()
+        tree = screen.query_one("#node-tree", Tree)
+        node_add = next(
+            n for n in tree.root.children if n.data and n.data[0] == "add_treatment"
+        )
+        tree._cursor_node = node_add
+        monkeypatch.setattr("cli.screens.run._open_in_editor", lambda *a, **k: None)
+        screen.action_edit_selected_node()
+    lines = cfg.read_text().splitlines()
+    idx = lines.index("  treatment_b:") + 2
+    assert lines[idx] == "  # new treatment"
+
+
+@pytest.mark.asyncio
+async def test_color_rendering(tmp_path: Path) -> None:
+    cfg = _write_config(tmp_path)
+    exp = Experiment.from_yaml(cfg)
+    plugin = exp.get_plugin(ArtifactPlugin)
+    plugin.root_dir = str(tmp_path)
+    screen = RunScreen(exp, cfg, False, None)
+
+    class AppTest(App):
+        async def on_mount(self) -> None:  # pragma: no cover - helper
+            await self.push_screen(screen)
+
+    app = AppTest()
+    async with app.run_test() as pilot:
+        screen._reload_object()
+        plugin = screen._obj.get_plugin(ArtifactPlugin)
+        plugin.root_dir = str(tmp_path)
+        screen._build_tree()
+        tree = screen.query_one("#node-tree", Tree)
+        node_a = next(
+            n for n in tree.root.children if n.data and n.data[1] == "treatment_a"
+        )
+        node_b = next(
+            n for n in tree.root.children if n.data and n.data[1] == "treatment_b"
+        )
+        tree._cursor_node = node_b
+        screen.action_toggle_treatment()
+        assert node_a._label.style == "color:green"
+        assert node_b._label.style == "color:red"

--- a/tests/test_treatment_panel.py
+++ b/tests/test_treatment_panel.py
@@ -109,7 +109,7 @@ async def test_toggle_state_persistence(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_summary_shows_inactive_metrics(tmp_path: Path) -> None:
+async def test_summary_shortcut_shows_inactive_metrics(tmp_path: Path) -> None:
     cfg = _write_config(tmp_path)
     exp_first = Experiment.from_yaml(cfg)
     plugin = exp_first.get_plugin(ArtifactPlugin)
@@ -143,11 +143,16 @@ async def test_summary_shows_inactive_metrics(tmp_path: Path) -> None:
         plugin.root_dir = str(tmp_path)
         result = await screen._obj.arun(strategy="rerun")
         screen._experiments = [screen._obj]
-        screen.render_summary(result, highlight="treatment_b")
+        screen._result = result
+        screen.render_summary(result)
         text = screen.summary_plain_text
-        assert "treatment_a" in text and "treatment_b" in text
-        assert text.index("treatment_b") < text.index("treatment_a")
+        assert "treatment_a" in text and "treatment_b" not in text
+        tree._cursor_node = node_b
+        tree.focus()
         screen.action_summary()
+        text_all = screen.summary_plain_text
+        assert "treatment_a" in text_all and "treatment_b" in text_all
+        assert text_all.index("treatment_b") < text_all.index("treatment_a")
         assert screen.query_one("#summary_log").visible
 
 

--- a/tests/test_treatment_panel.py
+++ b/tests/test_treatment_panel.py
@@ -204,6 +204,6 @@ async def test_color_rendering(tmp_path: Path) -> None:
             n for n in tree.root.children if n.data and n.data[1] == "treatment_b"
         )
         tree._cursor_node = node_b
-        screen.action_toggle_treatment()
+        label_b = screen.action_toggle_treatment()
         assert "color:green" in str(node_a.label.style)
-        assert "color:red" in str(node_b.label.style)
+        assert label_b is not None and "color:red" in str(label_b.style)

--- a/tests/test_treatment_panel.py
+++ b/tests/test_treatment_panel.py
@@ -141,7 +141,7 @@ async def test_summary_shows_inactive_metrics(tmp_path: Path) -> None:
         screen._reload_object()
         plugin = screen._obj.get_plugin(ArtifactPlugin)
         plugin.root_dir = str(tmp_path)
-        result = await screen._obj.arun(strategy="resume")
+        result = await screen._obj.arun(strategy="rerun")
         screen._experiments = [screen._obj]
         screen.render_summary(result, highlight="treatment_b")
         text = screen.summary_plain_text
@@ -208,10 +208,27 @@ async def test_color_rendering(tmp_path: Path) -> None:
             n for n in tree.root.children if n.data and n.data[1] == "treatment_b"
         )
         tree.focus()
+        screen._on_treatment_highlighted(Tree.NodeHighlighted(node_a))
+        assert (
+            tree.highlight_style
+            and tree.highlight_style.color
+            and tree.highlight_style.color.name == "green3"
+        )
         tree._cursor_node = node_b
+        screen._on_treatment_highlighted(Tree.NodeHighlighted(node_b))
+        assert (
+            tree.highlight_style
+            and tree.highlight_style.color
+            and tree.highlight_style.color.name == "green3"
+        )
         label_b = screen.action_toggle_treatment()
         assert str(node_a.label.style) == "green"
         assert label_b is not None and str(label_b.style) == "red"
+        assert (
+            tree.highlight_style
+            and tree.highlight_style.color
+            and tree.highlight_style.color.name == "red3"
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 📖 Summary of Documentation Changes
- Documented treatment sidebar shortcuts in Getting Started

## ✏️ Changes
- Support toggling, editing and adding treatments in RunScreen sidebar
- Persist inactive treatments and colour-code nodes
- Reorder and style summary metrics while loading artifacts from disk
- Add tests for treatment panel behaviour

## ✅ Testing & Verification
- [x] `pixi run lint`
- [x] `pixi run test`
- [x] `pixi run cov`
- [x] `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_68904e05ec7c832995594969b79a4809