### PR TITLE
fix(cli): handle nested experiment names in status plugin

### DIFF
--- a/cli/status_plugin.py
+++ b/cli/status_plugin.py
@@ -161,6 +161,7 @@ class CLIStatusPlugin(BasePlugin):
         cache_dir = Path.home() / ".cache" / "crystallize" / "steps"
         cache_dir.mkdir(parents=True, exist_ok=True)
         hist_file = cache_dir / f"{experiment.name}.json"
+        hist_file.parent.mkdir(parents=True, exist_ok=True)
         try:
             history = json.loads(hist_file.read_text())
         except Exception:

--- a/tests/test_cli_status_plugin.py
+++ b/tests/test_cli_status_plugin.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from crystallize import data_source, pipeline_step
 from crystallize.experiments.experiment import Experiment
 from crystallize.experiments.experiment_graph import ExperimentGraph
@@ -86,3 +88,18 @@ def test_before_step_emits_initial_progress() -> None:
     plugin.before_replicate(exp, ctx)
     plugin.before_step(exp, exp.pipeline.steps[0])
     assert ("step", {"step": exp.pipeline.steps[0].__class__.__name__, "percent": 0.0}) in events
+
+
+def test_after_run_creates_nested_history(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    plugin = CLIStatusPlugin(lambda e, i: None)
+    exp = Experiment(
+        datasource=ds(),
+        pipeline=Pipeline([step_a()]),
+        plugins=[plugin],
+        name="z/super_cluster",
+    )
+    exp.validate()
+    exp.run()
+    hist = tmp_path / ".cache" / "crystallize" / "steps" / "z" / "super_cluster.json"
+    assert hist.exists()


### PR DESCRIPTION
## 📖 Summary of Documentation Changes
- N/A

## ✏️ Changes
- ensure CLIStatusPlugin creates parent directories before writing history
- add regression test for nested experiment name histories

## ✅ Testing & Verification
- [x] Reviewed changes locally
- [x] Verified links and references
- [x] `pixi run lint`
- [x] `pixi run test`
- [x] `pixi run cov`
- [x] `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_689141a0dab0832996b946a82fb6c5b3