### PR TITLE
feat(cli): show artifact links in summary

### DIFF
--- a/docs/adr/0003-artifact-summary-table.md
+++ b/docs/adr/0003-artifact-summary-table.md
@@ -1,0 +1,15 @@
+# ADR 0003: Link artifacts in experiment summary
+
+## Context & Problem
+The CLI summary only displayed metrics and hypothesis results, making it hard to locate artifacts generated during runs.
+
+## Decision
+Record artifact file paths during experiment execution and render them in a summary table with clickable links.
+
+## Alternatives Considered
+- Rely on manual file browsing to inspect artifacts.
+- Show artifact names without linking to their locations.
+
+## Consequences
+- Users can open produced artifacts directly from the summary.
+- Result objects now store paths to artifacts, increasing memory usage slightly.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -79,6 +79,7 @@ print(output)
 - Optional parallel execution for heavy experiments.
 - Configurable worker count and executor type ("thread" or "process").
 - Run screen sidebar can toggle treatments (`x`), edit (`e`) and jump to the summary (`S`) with color-coded states.
+- Summary tab lists metrics, artifacts and hypotheses with links for quick inspection.
 
 For heavy parallel workloads, ensure the cache directory supports file locks or
 switch to a thread-safe backend.

--- a/docs/src/content/docs/cli/tutorial-cli-workflow.md
+++ b/docs/src/content/docs/cli/tutorial-cli-workflow.md
@@ -35,9 +35,10 @@ Let's run our new experiment without any modifications.
 
 ### Step 3: The Summary Tab – Instant Results!
 
-After the run, the view switches to the **Summary** tab. Because we included example code, the summary is already populated with meaningful results. You'll see two main tables:
+After the run, the view switches to the **Summary** tab. Because we included example code, the summary is already populated with meaningful results. You'll see three main tables:
 
 - **Metrics Table:** Shows the raw metrics collected during the run. The example code calculates a `val` metric, and you can see how its value differs between the baseline, `increase_by_one`, and `increase_by_two` treatments.
+- **Artifacts Table:** Lists the artifacts saved during the run. Each cell links to the file produced by the corresponding treatment so you can open it directly.
 - **Hypothesis Table:** Displays the results of the statistical test defined in the example. It compares each treatment to the baseline and reports a `p_value` and whether the result was significant.
 
 Just by scaffolding and running, you've already got a complete experimental result!

--- a/docs/src/content/docs/cli/tutorial-graph-experiment.md
+++ b/docs/src/content/docs/cli/tutorial-graph-experiment.md
@@ -113,4 +113,4 @@ When you run `comfort-index` in the TUI, Crystallize automatically executes its 
 - `humidity-stats` runs once.
 - `comfort-index` runs 30 times, consuming the produced artifacts.
 
-The summary shows metrics and hypothesis results for all experiments, demonstrating how graphs let you orchestrate complex workflows.
+The summary shows metrics, artifacts, and hypothesis results for all experiments, demonstrating how graphs let you orchestrate complex workflows.

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -92,6 +92,19 @@ def test_artifacts_respect_experiment_name(tmp_path: Path, monkeypatch):
     assert expected.read_text() == "hello"
 
 
+def test_result_contains_artifact_paths(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    pipeline = Pipeline([LogStep()])
+    ds = DummySource()
+    plugin = ArtifactPlugin(root_dir=str(tmp_path / "arts"))
+    exp = Experiment(datasource=ds, pipeline=pipeline, plugins=[plugin])
+    exp.validate()
+    res = exp.run()
+    art_map = res.artifacts.get("out.txt")
+    assert art_map is not None and "baseline" in art_map
+    assert Path(art_map["baseline"]).exists()
+
+
 def test_artifact_datasource_before_run(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     pipeline = Pipeline([LogStep()])


### PR DESCRIPTION
## 📖 Summary of Documentation Changes
- Document artifact table in CLI tutorials and getting started guide
- Record decision in ADR 0003

## ✏️ Changes
- Expose artifact file paths from `ArtifactPlugin`
- Render clickable artifact table in experiment summaries
- Update docs and tests for new artifact summary

## ✅ Testing & Verification
- [x] Reviewed changes locally
- [x] Verified links and references
- [x] `pixi run lint`
- [x] `pixi run test`
- [x] `pixi run cov`
- [x] `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_68920725ba1c8329b886019cfdfce4cf