### PR TITLE
Fix: cooperative cancellation for run screen

### DIFF
--- a/docs/adr/0004-cooperative-cancel.md
+++ b/docs/adr/0004-cooperative-cancel.md
@@ -1,0 +1,21 @@
+# ADR 0004: Cooperative cancellation for RunScreen experiments
+
+## Context & Problem
+
+The RunScreen used `asyncio.run` to execute experiments, preventing the Cancel button from stopping the running coroutine. This often left runs lingering and made the UI unresponsive.
+
+## Decision
+
+Create an explicit event loop and task in the worker thread so the Cancel button can request `task.cancel()` via `loop.call_soon_threadsafe`, allowing cooperative cancellation.
+
+## Alternatives Considered
+
+- Keep using `asyncio.run` (simple but impossible to cancel once started).
+- Forcefully terminate the worker thread (unsafe; risks resource leaks).
+
+## Consequences
+
+- Cancellation propagates quickly and cleanly.
+- Slightly more complex worker setup.
+- If cancellation stalls, the UI warns and offers an unsafe force stop.
+

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -79,6 +79,7 @@ print(output)
 - Optional parallel execution for heavy experiments.
 - Configurable worker count and executor type ("thread" or "process").
 - Run screen sidebar can toggle treatments (`x`), edit (`e`) and jump to the summary (`S`) with color-coded states.
+- Run screen provides a Cancel button to stop experiments mid-execution.
 - Summary tab lists metrics, artifacts and hypotheses with links for quick inspection.
 
 For heavy parallel workloads, ensure the cache directory supports file locks or


### PR DESCRIPTION
## 📖 Summary of Documentation Changes
- Document Run screen cancel capability
- Record ADR for cooperative cancellation design

## ✏️ Changes
- Use dedicated event loop and task to allow cancelling experiment coroutine
- Update Run screen logic to schedule task cancellation and handle timeouts
- Describe new cancel button behavior in getting started guide
- Add ADR for cooperative cancellation

## ✅ Testing & Verification
- [x] `pixi run lint`
- [x] `pixi run test`
- [x] `pixi run cov`
- [x] `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_68950e3afe5c8329b568e8eff076fdf7