### PR TITLE
fix: close WidgetWriter duplicate FDs

### DIFF
--- a/cli/status_plugin.py
+++ b/cli/status_plugin.py
@@ -252,3 +252,17 @@ class TextualLoggingPlugin(LoggingPlugin):
     def before_step(self, experiment: Experiment, step: PipelineStep) -> None:
         exp_var.set(experiment.name)
         step_var.set(step.__class__.__name__)
+
+    def after_run(self, experiment: Experiment, result: Any) -> None:
+        super().after_run(experiment, result)
+
+        logger = logging.getLogger("crystallize")
+        for handler in list(logger.handlers):
+            if isinstance(handler, self.handler_cls):
+                handler.close()
+                logger.removeHandler(handler)
+
+        logger.propagate = False
+
+        if self.writer and hasattr(self.writer, "close"):
+            self.writer.close()

--- a/cli/widgets/writer.py
+++ b/cli/widgets/writer.py
@@ -74,5 +74,8 @@ class WidgetWriter:
     def close(self) -> None:
         """Close the cached duplicate FD if it exists."""
         if self._dup_fd is not None:
-            os.close(self._dup_fd)
+            try:
+                os.close(self._dup_fd)
+            except OSError:
+                pass
             self._dup_fd = None

--- a/cli/widgets/writer.py
+++ b/cli/widgets/writer.py
@@ -43,6 +43,7 @@ class WidgetWriter:
         self.widget = widget
         self.app = app
         self.history = history
+        self._dup_fd: int | None = None
 
     def write(self, message: str) -> None:
         if self.history is not None:
@@ -60,6 +61,18 @@ class WidgetWriter:
         return True
 
     def fileno(self) -> int:
-        # Return a unique duplicate of the real stdout FD
-        # to avoid FD list duplication in multiprocessing
-        return os.dup(sys.__stdout__.fileno())
+        """Return a dup'd FD for the underlying stdout.
+
+        The FD is duplicated only once and cached to avoid leaking
+        descriptors on repeated ``fileno`` calls.
+        """
+
+        if self._dup_fd is None:
+            self._dup_fd = os.dup(sys.__stdout__.fileno())
+        return self._dup_fd
+
+    def close(self) -> None:
+        """Close the cached duplicate FD if it exists."""
+        if self._dup_fd is not None:
+            os.close(self._dup_fd)
+            self._dup_fd = None

--- a/docs/adr/0004-widgetwriter-fd-cache.md
+++ b/docs/adr/0004-widgetwriter-fd-cache.md
@@ -1,0 +1,19 @@
+# ADR 0004: Cache duplicate FD in WidgetWriter
+
+## Context & Problem
+
+`WidgetWriter.fileno()` duplicated the real stdout file descriptor on each call, leaking descriptors during long-running sessions.
+
+## Decision
+
+Cache a single duplicated file descriptor within `WidgetWriter` and close it explicitly when runs finish.
+
+## Alternatives Considered
+
+- Duplicate on every `fileno()` call – simple but leaks descriptors.
+- Return `sys.__stdout__.fileno()` directly – risks interference with the real stdout in multiprocessing contexts.
+
+## Consequences
+
+- Prevents file descriptor leaks across runs.
+- Requires plugins to close the `WidgetWriter` after use to release the descriptor.

--- a/tests/test_widget_writer.py
+++ b/tests/test_widget_writer.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+
+from cli.widgets.writer import WidgetWriter
+
+
+class DummyWidget:
+    def write(self, msg: str) -> None:  # pragma: no cover - stub
+        pass
+
+    def refresh(self) -> None:  # pragma: no cover - stub
+        pass
+
+
+class DummyApp:
+    def call_from_thread(self, func, *args, **kwargs) -> None:  # pragma: no cover
+        func(*args, **kwargs)
+
+
+def test_widget_writer_caches_fd_and_closes() -> None:
+    writer = WidgetWriter(DummyWidget(), DummyApp())
+
+    fd1 = writer.fileno()
+    fd2 = writer.fileno()
+    assert fd1 == fd2
+
+    writer.close()
+
+    try:
+        os.fstat(fd1)
+    except OSError:
+        pass
+    else:  # pragma: no cover - fd still open
+        raise AssertionError("duplicate fd was not closed")
+
+    fd3 = writer.fileno()
+    os.fstat(fd3)
+    writer.close()


### PR DESCRIPTION
## 📖 Summary of Documentation Changes
- Added ADR on caching duplicated file descriptors in WidgetWriter

## ✏️ Changes
- Cache duplicated stdout fd in `WidgetWriter` and expose `close`
- Clean up logging handlers in `TextualLoggingPlugin.after_run`
- Test to ensure `WidgetWriter` reuses and closes fds
- Document the decision in ADR 0004

## ✅ Testing & Verification
- [x] Reviewed changes locally
- [x] Verified links and references
- [x] `pixi run lint`
- [x] `pixi run test`
- [x] `pixi run cov`
- [x] `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_68950e2b88848329a45b4e41274bc3b8