### PR TITLE
fix(cli): reset widget log handler each run

### DIFF
--- a/docs/adr/0004-reset-widget-log-handler.md
+++ b/docs/adr/0004-reset-widget-log-handler.md
@@ -1,0 +1,15 @@
+# ADR 0004: Reset Widget Log Handler Each Run
+
+## Context & Problem
+Reloading the TUI left old `WidgetLogHandler` instances attached to the `crystallize` logger. Subsequent runs could miss log messages or display them multiple times.
+
+## Decision
+`TextualLoggingPlugin.before_run` now removes existing handlers and attaches a fresh `WidgetLogHandler` for each run when a writer is available, guaranteeing exactly one active handler.
+
+## Alternatives Considered
+- **Keep existing handler:** left stale widget bindings and duplicated logs.
+- **Track handlers via global state:** added unnecessary complexity and state management.
+
+## Consequences
+- Logging remains consistent across sequential runs.
+- Minor overhead of re-creating the handler every run.

--- a/tests/test_textual_logging_plugin.py
+++ b/tests/test_textual_logging_plugin.py
@@ -1,0 +1,59 @@
+import logging
+
+from cli.status_plugin import ContextFilter, TextualLoggingPlugin, WidgetLogHandler
+from cli.widgets.writer import WidgetWriter
+
+
+class DummyWidget:
+    def write(self, msg: str) -> None:  # pragma: no cover - simple stub
+        pass
+
+    def refresh(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+
+class DummyApp:
+    def call_from_thread(self, func, *args, **kwargs) -> None:  # pragma: no cover
+        func(*args, **kwargs)
+
+
+class DummyExperiment:
+    replicates = 1
+    treatments: list = []
+    hypotheses: list = []
+
+    def get_plugin(self, cls):  # pragma: no cover - simple stub
+        return None
+
+
+def test_textual_logging_plugin_resets_handlers() -> None:
+    logger = logging.getLogger("crystallize")
+    logger.handlers.clear()
+    logger.filters.clear()
+
+    writer = WidgetWriter(DummyWidget(), DummyApp(), [])
+    plugin = TextualLoggingPlugin(writer=writer)
+    exp = DummyExperiment()
+
+    plugin.before_run(exp)
+    handlers = [h for h in logger.handlers if isinstance(h, WidgetLogHandler)]
+    assert len(handlers) == 1
+    first_id = id(handlers[0])
+    assert sum(isinstance(f, ContextFilter) for f in logger.filters) == 1
+    assert not logger.propagate
+
+    plugin.before_run(exp)
+    handlers = [h for h in logger.handlers if isinstance(h, WidgetLogHandler)]
+    assert len(handlers) == 1
+    assert id(handlers[0]) != first_id
+    second_id = id(handlers[0])
+    assert sum(isinstance(f, ContextFilter) for f in logger.filters) == 1
+    assert not logger.propagate
+
+    no_writer = TextualLoggingPlugin(writer=None)
+    no_writer.before_run(exp)
+    handlers = [h for h in logger.handlers if isinstance(h, WidgetLogHandler)]
+    assert len(handlers) == 1
+    assert id(handlers[0]) == second_id
+    assert sum(isinstance(f, ContextFilter) for f in logger.filters) == 1
+    assert not logger.propagate


### PR DESCRIPTION
## 📖 Summary of Documentation Changes
- Updated ADR to clarify handler reset occurs only when a writer is present.

## ✏️ Changes
- Reset crystallize logger handlers at run start only when a widget writer exists.
- Preserve logger state when the logging plugin lacks a writer.
- Extended regression test to verify handler replacement and no-op behavior without a writer.

## ✅ Testing & Verification
- [x] Reviewed changes locally
- [x] Verified links and references
- [x] `pixi run lint`
- [x] `pixi run test`
- [x] `pixi run cov`
- [x] `pixi run diff-cov`
- [ ] Requested review from relevant stakeholders (optional)


------
https://chatgpt.com/codex/tasks/task_e_68950f2ee5d88329b2ff5a70c3064c58