### PR TITLE
fix: enforce replicate consistency and add strict root finder option

### DIFF
--- a/docs/adr/0004-experiment-input-replicate-consistency.md
+++ b/docs/adr/0004-experiment-input-replicate-consistency.md
@@ -1,0 +1,16 @@
+# ADR 0004: Enforce Replicate Consistency in ExperimentInput
+
+## Context & Problem
+ExperimentInput previously inferred the number of replicates from only the first artifact input, which could mask mismatched replicate counts across artifacts.
+
+## Decision
+Gather replicates from all artifact inputs, raising a ValueError when conflicting counts are detected.
+
+## Alternatives Considered
+- **First artifact wins**: keep existing behavior and allow mismatches.
+- **Silently pick max/min**: choose a replicate count without validation.
+
+## Consequences
+- **Positive**: Prevents subtle bugs caused by mixing artifacts with different replicate counts.
+- **Negative**: Construction now errors if upstream artifacts are misconfigured.
+

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -12,7 +12,7 @@ Crystallize enables reproducible data-science experiments by structuring runs as
   - `datasource.py` – abstract base class for data providers and the `ExperimentInput` aggregator.
   - `__init__.py` – exposes artifact utilities.
 - **Relationships / Dependencies:** Uses `utils.context` for execution context and interacts with `plugins.ArtifactPlugin` for persistence. `ExperimentInput` may depend on outputs from other experiments.
-- **Notes / Edge Cases:** `ExperimentInput` infers replicate counts from the first artifact input and raises if constructed without inputs.
+- **Notes / Edge Cases:** `ExperimentInput` validates replicate counts across artifact inputs and raises on conflicts or missing inputs.
 
 ### experiments
 - **Responsibility:** Define and execute experiments, manage treatments and hypotheses, and aggregate results.

--- a/docs/src/content/docs/reference/datasource.md
+++ b/docs/src/content/docs/reference/datasource.md
@@ -62,11 +62,8 @@ __init__(**inputs: crystallize.core.datasource.DataSource) → None
 
 #### <kbd>property</kbd> ExperimentInput.replicates
 
-
-
-
-
-
+Number of replicates inferred from artifact inputs.
+If artifacts provide conflicting counts, construction raises ``ValueError``.
 
 ---
 

--- a/tests/test_experiment_input.py
+++ b/tests/test_experiment_input.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import pytest
+
+from crystallize.datasources.artifacts import Artifact
+from crystallize.datasources.datasource import ExperimentInput
+from crystallize.utils.context import FrozenContext
+
+
+class DummyArtifact(Artifact):
+    def __init__(self, name: str, value: str, replicates: int | None) -> None:
+        super().__init__(name, loader=lambda p: value)
+        self.replicates = replicates
+
+    def fetch(self, ctx: FrozenContext):  # type: ignore[override]
+        return self.loader(Path())
+
+
+def test_matching_replicates_sets_value() -> None:
+    ds = ExperimentInput(
+        a=DummyArtifact("a", "A", 2),
+        b=DummyArtifact("b", "B", 2),
+    )
+    assert ds.replicates == 2
+
+
+def test_mismatched_replicates_raise() -> None:
+    with pytest.raises(ValueError, match="Conflicting replicates"):
+        ExperimentInput(
+            a=DummyArtifact("a", "A", 2),
+            b=DummyArtifact("b", "B", 3),
+        )

--- a/tests/test_find_experiments_root.py
+++ b/tests/test_find_experiments_root.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import logging
+
+import pytest
+
+from crystallize.experiments.experiment_graph import find_experiments_root
+
+
+def test_find_experiments_root_finds_existing(tmp_path: Path) -> None:
+    root = tmp_path / "experiments"
+    root.mkdir()
+    subdir = root / "a" / "b"
+    subdir.mkdir(parents=True)
+    assert find_experiments_root(subdir) == root
+
+
+def test_find_experiments_root_raises_when_missing(tmp_path: Path) -> None:
+    start = tmp_path / "a" / "b"
+    start.mkdir(parents=True)
+    with pytest.raises(FileNotFoundError):
+        find_experiments_root(start)
+
+
+def test_find_experiments_root_warns_and_returns_start_when_non_strict(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    start = tmp_path / "a" / "b"
+    start.mkdir(parents=True)
+    with caplog.at_level(logging.WARNING):
+        result = find_experiments_root(start, strict=False)
+    assert result == start
+    assert "Could not locate 'experiments' dir" in caplog.text

--- a/tests/test_from_yaml.py
+++ b/tests/test_from_yaml.py
@@ -290,12 +290,15 @@ def test_from_yaml_unused_output(tmp_path: Path):
 
 
 def test_graph_from_yaml_recursive(tmp_path: Path):
-    prod_dir = create_exp(tmp_path, name="producer")
+    root = tmp_path / "experiments"
+    root.mkdir()
+
+    prod_dir = create_exp(root, name="producer")
     prod = Experiment.from_yaml(prod_dir / "config.yaml")
     prod.validate()
     prod.run()
 
-    cons = tmp_path / "consumer"
+    cons = root / "consumer"
     cons.mkdir()
     (cons / "datasources.py").write_text(
         "from crystallize import data_source\n"


### PR DESCRIPTION
## 📖 Summary of Documentation Changes
- Document replicate consistency validation and decision
- Clarify experiments root finder behavior and strict option

## ✏️ Changes
- enforce replicate consistency across artifact inputs
- add `strict` flag to `find_experiments_root` and handle missing roots
- add tests for replicate mismatches and root finder behaviors

## ✅ Testing & Verification
- [x] Reviewed changes locally
- [x] Verified links and references
- [x] `pixi run lint`
- [x] `pixi run test`
- [x] `pixi run cov`
- [x] `pixi run diff-cov`


------
https://chatgpt.com/codex/tasks/task_e_68950c1264388329926df953416be778