### PR TITLE
feat: add optional strong experiment ids

### DIFF
--- a/docs/adr/0005-strong-experiment-ids.md
+++ b/docs/adr/0005-strong-experiment-ids.md
@@ -1,0 +1,16 @@
+# ADR 0005: Strong Experiment IDs
+
+## Context & Problem
+Experiment identifiers were derived solely from the pipeline signature, so runs with identical pipelines but different datasource parameters or treatments could collide.
+
+## Decision
+Introduce optional strong identifiers that incorporate datasource parameters, treatment details, and replicates when the environment variable `CRYSTALLIZE_STRONG_IDS=1` is set.
+
+## Alternatives Considered
+- Always include datasource and treatment details in the identifier – would break existing experiment directories and caches.
+- Use random or timestamp-based IDs – sacrifices reproducibility and traceability.
+
+## Consequences
+- Default behaviour remains unchanged, ensuring backward compatibility.
+- When enabled, experiments with different datasources, treatments, or replicate counts produce distinct IDs, reducing collisions.
+- Slightly more computation is required to hash the richer payload.

--- a/docs/src/content/docs/explanation/reproducibility.md
+++ b/docs/src/content/docs/explanation/reproducibility.md
@@ -20,3 +20,10 @@ Each `PipelineStep` is hashed along with its inputs. When a step is cacheable, C
 ## Declarative Experiments
 
 The `Experiment` class defines data sources, pipelines, treatments, hypotheses, and plugins purely in code. Because the entire configuration lives in a Python module (or YAML file), it can be version controlled and shared. Re-running an experiment with the same code and data reproduces the exact sequence of steps and results.
+
+## Collision-Resistant Identifiers
+
+Experiment IDs normally hash only the pipeline signature. To avoid accidental
+collisions across differing datasources or treatments, set the environment
+variable `CRYSTALLIZE_STRONG_IDS=1` and the ID will also include datasource
+parameters, treatments, and replicates.

--- a/tests/test_strong_ids.py
+++ b/tests/test_strong_ids.py
@@ -1,0 +1,68 @@
+from crystallize.experiments.experiment import Experiment
+from crystallize.datasources.datasource import DataSource
+from crystallize.experiments.treatment import Treatment
+from crystallize.pipelines.pipeline import Pipeline
+from crystallize.pipelines.pipeline_step import PipelineStep
+from crystallize.utils.context import FrozenContext
+
+
+class ParamDataSource(DataSource):
+    def __init__(self, value: int) -> None:
+        self.value = value
+        self.params = {"value": value}
+
+    def fetch(self, ctx: FrozenContext):
+        return self.value
+
+
+class RecordStep(PipelineStep):
+    def __call__(self, data, ctx):
+        ctx.metrics.add("metric", data)
+        return {"metric": data}
+
+    @property
+    def params(self):
+        return {}
+
+
+def test_strong_ids_toggle(monkeypatch):
+    pipeline = Pipeline([RecordStep()])
+    treatment_a = Treatment("a", {"increment": 1})
+    treatment_b = Treatment("b", {"increment": 2})
+
+    exp1 = Experiment(
+        datasource=ParamDataSource(1), pipeline=pipeline, treatments=[treatment_a]
+    )
+    exp2 = Experiment(
+        datasource=ParamDataSource(2), pipeline=pipeline, treatments=[treatment_b]
+    )
+    exp1.validate()
+    exp2.validate()
+    exp1.run()
+    exp2.run()
+    assert exp1.id == exp2.id
+
+    monkeypatch.setenv("CRYSTALLIZE_STRONG_IDS", "1")
+    exp3 = Experiment(
+        datasource=ParamDataSource(1), pipeline=pipeline, treatments=[treatment_a]
+    )
+    exp4 = Experiment(
+        datasource=ParamDataSource(2), pipeline=pipeline, treatments=[treatment_b]
+    )
+    exp3.validate()
+    exp4.validate()
+    exp3.run()
+    exp4.run()
+    assert exp3.id != exp4.id
+
+    exp5 = Experiment(
+        datasource=ParamDataSource(1), pipeline=pipeline, treatments=[treatment_a]
+    )
+    exp6 = Experiment(
+        datasource=ParamDataSource(1), pipeline=pipeline, treatments=[treatment_a]
+    )
+    exp5.validate()
+    exp6.validate()
+    exp5.run(replicates=1)
+    exp6.run(replicates=2)
+    assert exp5.id != exp6.id


### PR DESCRIPTION
## 📖 Summary of Documentation Changes
- Clarified ADR 0005: strong IDs distinguish differing replicate counts.

## ✏️ Changes
- Hash effective replicate count when computing strong experiment IDs in `run` and `apply`.
- Extended regression test to cover differing replicate counts.

## ✅ Testing & Verification
- [x] `pixi run lint`
- [x] `pixi run test`
- [x] `pixi run cov`
- [x] `pixi run diff-cov`
- [ ] `mypy crystallize tests` *(fails: unsupported operand types and invalid index types)*

------
https://chatgpt.com/codex/tasks/task_e_6895191b91988329b7fa7c0873c38cb2